### PR TITLE
feat: 자동 로그인(로그인 유지) 기능 구현

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
+import 'package:nutripic/models/user_model.dart';
 import 'package:nutripic/utils/app_router.dart';
 
 Future<void> main() async {
@@ -13,7 +14,11 @@ Future<void> main() async {
   runApp(const MainApp());
 }
 
-final _router = AppRouter.getRouter();
+// 모델
+UserModel userModel = UserModel();
+
+// 라우터
+final _router = AppRouter.getRouter(userModel);
 
 class MainApp extends StatelessWidget {
   const MainApp({super.key});

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -11,7 +12,19 @@ Future<void> main() async {
   await Firebase.initializeApp();
   KakaoSdk.init(nativeAppKey: dotenv.env['KAKAO_NATIVE_APP_KEY']);
 
+  // 가능하다면 자동 로그인 진행
+  await autoLogin();
+
   runApp(const MainApp());
+}
+
+/// Firebase 로그인 정보가 있는지 확인 후 있다면 사용자 정보를 모델에 저장하는 함수
+Future<void> autoLogin() async {
+  // Firebase 로그인이 된 상태라면 서버에서 사용자 정보 요청
+  if (FirebaseAuth.instance.currentUser != null) {
+    userModel.uid = FirebaseAuth.instance.currentUser!.uid;
+    userModel.name = FirebaseAuth.instance.currentUser!.displayName;
+  }
 }
 
 // 모델

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class UserModel with ChangeNotifier {
+  /// Firebase에서 제공하는 uid
+  String? uid;
+
+  /// 사용자 이름
+  String? name;
+
+  /// 사용자 프로필 사진 url
+  String? profileUrl;
+
+  UserModel({
+    this.uid,
+    this.name,
+    this.profileUrl,
+  });
+
+  /// 서버에서 받아온 사용자 데이터를 모델에 저장하는 함수
+  void fromJson(Map<String, dynamic> jsonData) {
+    uid = jsonData['uid'];
+    name = jsonData['name'];
+    profileUrl = jsonData['profileUrl'];
+  }
+
+  /// 모델 데이터를 초기화하는 함수
+  void reset() {
+    uid = null;
+    name = null;
+    profileUrl = null;
+  }
+
+  // 모델 프린트 형식
+  @override
+  String toString() {
+    return 'uid: $uid, '
+        'name: $name, '
+        'profileUrl: $profileUrl';
+  }
+}

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -1,27 +1,55 @@
 import 'dart:convert';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 
 class API {
   static String baseUrl = dotenv.env['API_URL']!;
+  static final _firebaseAuth = FirebaseAuth.instance;
+
+  /// Firebase 인증을 위한 사용자 id token을 반환하는 함수
+  ///
+  /// 토큰이 만료되었다면 firebase에서 새로 발급한 토큰 반환, 만료되지 않았다면 현재 토큰을 반환
+  /// </br> Firebase 로그인이 되어있지 않은 상태에서 토큰을 요청하면 `user-not-found` 오류 반환
+  static Future<String?> _getToken() async {
+    String? token;
+
+    if (_firebaseAuth.currentUser != null) {
+      token = await _firebaseAuth.currentUser!.getIdToken();
+    } else {
+      throw ErrorDescription('user-not-found');
+    }
+
+    return token;
+  }
 
   /* BASE API (GET, POST, PATCH, DELETE) */
 
   /// ### API GET
   /// 데이터를 받아올 때 사용
   ///
+  /// `tokenRequired`를 `false`로 설정하면 API 요청시 토큰을 헤더에 포함시키지 않음.
+  ///
   /// 요청 성공시 `response.body`를 반환.
   /// </br> `response is Map<String, dynamic>` 확인 후 데이터 접근 할 것.
   ///
   /// 요청 실패시 `response`를 반환.
   /// </br>`statusCode`로 에러 확인 후 메시지 출력.
-  static Future<dynamic> _getApi(String endPoint) async {
+  static Future<dynamic> _getApi(String endPoint,
+      {bool tokenRequired = true}) async {
     String apiUrl = '$baseUrl/$endPoint';
+    Map<String, String> headers = {};
     debugPrint('GET 요청: $endPoint');
 
     try {
-      final response = await http.get(Uri.parse(apiUrl));
+      // 헤더에 토큰 추가
+      if (tokenRequired) {
+        String? token = await _getToken();
+        headers['Authorization'] = 'Bearer $token';
+      }
+
+      final response = await http.get(Uri.parse(apiUrl), headers: headers);
 
       if (response.statusCode == 200) {
         debugPrint('GET 요청 성공');
@@ -40,13 +68,22 @@ class API {
   /// ### API POST
   /// 데이터 생성시 사용
   ///
+  /// `tokenRequired`를 `false`로 설정하면 API 요청시 토큰을 헤더에 포함시키지 않음.
+  ///
   /// `response.statusCode == 200` 확인 후 요청 성공 로직 진행.
-  static Future<dynamic> _postApi(String endPoint, String jsonData) async {
+  static Future<dynamic> _postApi(String endPoint, String jsonData,
+      {bool tokenRequired = true}) async {
     String apiUrl = '$baseUrl/$endPoint';
     Map<String, String> headers = {'Content-Type': 'application/json'};
     debugPrint('POST 요청: $endPoint');
 
     try {
+      // 헤더에 토큰 추가
+      if (tokenRequired) {
+        String? token = await _getToken();
+        headers['Authorization'] = 'Bearer $token';
+      }
+
       final response =
           await http.post(Uri.parse(apiUrl), headers: headers, body: jsonData);
       if (response.statusCode == 200) {
@@ -65,13 +102,22 @@ class API {
   /// ### API PATCH
   /// 데이터 일부 수정시 사용
   ///
+  /// `tokenRequired`를 `false`로 설정하면 API 요청시 토큰을 헤더에 포함시키지 않음.
+  ///
   /// `response.statusCode == 200` 확인 후 요청 성공 로직 진행.
-  static Future<dynamic> _patchApi(String endPoint, String? jsonData) async {
+  static Future<dynamic> _patchApi(String endPoint, String? jsonData,
+      {bool tokenRequired = true}) async {
     String apiUrl = '$baseUrl/$endPoint';
     Map<String, String> headers = {'Content-Type': 'application/json'};
     debugPrint('PATCH 요청: $endPoint');
 
     try {
+      // 헤더에 토큰 추가
+      if (tokenRequired) {
+        String? token = await _getToken();
+        headers['Authorization'] = 'Bearer $token';
+      }
+
       final response =
           await http.patch(Uri.parse(apiUrl), headers: headers, body: jsonData);
       if (response.statusCode == 200) {
@@ -90,13 +136,23 @@ class API {
   /// ### API DELETE
   /// 데이터 삭제시 사용
   ///
+  /// `tokenRequired`를 `false`로 설정하면 API 요청시 토큰을 헤더에 포함시키지 않음.
+  ///
   /// `response.statusCode == 200` 확인 후 요청 성공 로직 진행.
-  static Future<dynamic> _deleteApi(String endPoint) async {
+  static Future<dynamic> _deleteApi(String endPoint,
+      {bool tokenRequired = true}) async {
     String apiUrl = '$baseUrl/$endPoint';
+    Map<String, String> headers = {};
     debugPrint('DELETE 요청: $endPoint');
 
     try {
-      final response = await http.delete(Uri.parse(apiUrl));
+      // 헤더에 토큰 추가
+      if (tokenRequired) {
+        String? token = await _getToken();
+        headers['Authorization'] = 'Bearer $token';
+      }
+
+      final response = await http.delete(Uri.parse(apiUrl), headers: headers);
 
       if (response.statusCode == 200) {
         debugPrint('DELETE 요청 성공');

--- a/lib/utils/app_router.dart
+++ b/lib/utils/app_router.dart
@@ -1,5 +1,8 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nutripic/view_models/home_view_model.dart';
 import 'package:nutripic/view_models/login_view_model.dart';
+import 'package:nutripic/views/home_view.dart';
 import 'package:nutripic/views/login_view.dart';
 import 'package:provider/provider.dart';
 
@@ -9,12 +12,34 @@ class AppRouter {
   static GoRouter getRouter() {
     return GoRouter(
       initialLocation: '/login',
+      redirect: (context, state) {
+        User? user = FirebaseAuth.instance.currentUser;
+
+        // Firebase 로그인이 된 상태라면 홈으로 이동, 아니면 로그인 화면으로 이동
+        if (user == null) {
+          return '/login';
+        } else if (state.fullPath == '/login') {
+          return '/home';
+        } else {
+          return null;
+        }
+      },
       routes: [
+        // 로그인
         GoRoute(
           path: '/login',
           builder: (context, state) => ChangeNotifierProvider(
             create: (context) => LoginViewModel(context: context),
             child: const LoginView(),
+          ),
+        ),
+
+        // 홈
+        GoRoute(
+          path: '/home',
+          builder: (context, state) => ChangeNotifierProvider(
+            create: (context) => HomeViewModel(context: context),
+            child: const HomeView(),
           ),
         )
       ],

--- a/lib/utils/app_router.dart
+++ b/lib/utils/app_router.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nutripic/models/user_model.dart';
 import 'package:nutripic/view_models/home_view_model.dart';
@@ -15,10 +14,9 @@ class AppRouter {
     return GoRouter(
       initialLocation: '/login',
       redirect: (context, state) {
-        User? user = FirebaseAuth.instance.currentUser;
-
-        // Firebase 로그인이 된 상태라면 홈으로 이동, 아니면 로그인 화면으로 이동
-        if (user == null) {
+        // 사용자 데이터가 있으면 firebase 로그인이 완료된 상태
+        // 사용자 데이터가 없으면 로그인 화면으로 이동, 있으면 홈 화면으로 이동
+        if (userModel.uid == null) {
           return '/login';
         } else if (state.fullPath == '/login') {
           return '/home';
@@ -31,7 +29,10 @@ class AppRouter {
         GoRoute(
           path: '/login',
           builder: (context, state) => ChangeNotifierProvider(
-            create: (context) => LoginViewModel(context: context),
+            create: (context) => LoginViewModel(
+              userModel: userModel,
+              context: context,
+            ),
             child: const LoginView(),
           ),
         ),
@@ -40,7 +41,10 @@ class AppRouter {
         GoRoute(
           path: '/home',
           builder: (context, state) => ChangeNotifierProvider(
-            create: (context) => HomeViewModel(context: context),
+            create: (context) => HomeViewModel(
+              userModel: userModel,
+              context: context,
+            ),
             child: const HomeView(),
           ),
         )

--- a/lib/utils/app_router.dart
+++ b/lib/utils/app_router.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nutripic/models/user_model.dart';
 import 'package:nutripic/view_models/home_view_model.dart';
 import 'package:nutripic/view_models/login_view_model.dart';
 import 'package:nutripic/views/home_view.dart';
@@ -7,9 +8,10 @@ import 'package:nutripic/views/login_view.dart';
 import 'package:provider/provider.dart';
 
 class AppRouter {
-  AppRouter();
+  final UserModel userModel;
+  AppRouter({required this.userModel});
 
-  static GoRouter getRouter() {
+  static GoRouter getRouter(UserModel userModel) {
     return GoRouter(
       initialLocation: '/login',
       redirect: (context, state) {

--- a/lib/view_models/home_view_model.dart
+++ b/lib/view_models/home_view_model.dart
@@ -1,0 +1,13 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class HomeViewModel with ChangeNotifier {
+  BuildContext context;
+  HomeViewModel({required this.context});
+
+  void logout() async {
+    await FirebaseAuth.instance.signOut();
+    if (context.mounted) context.go('/login');
+  }
+}

--- a/lib/view_models/home_view_model.dart
+++ b/lib/view_models/home_view_model.dart
@@ -1,13 +1,16 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nutripic/models/user_model.dart';
 
 class HomeViewModel with ChangeNotifier {
+  UserModel userModel;
   BuildContext context;
-  HomeViewModel({required this.context});
+  HomeViewModel({required this.userModel, required this.context});
 
   void logout() async {
     await FirebaseAuth.instance.signOut();
+    userModel.reset();
     if (context.mounted) context.go('/login');
   }
 }

--- a/lib/view_models/login_view_model.dart
+++ b/lib/view_models/login_view_model.dart
@@ -3,11 +3,13 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart' as kakao;
+import 'package:nutripic/models/user_model.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
 class LoginViewModel with ChangeNotifier {
+  UserModel userModel;
   BuildContext context;
-  LoginViewModel({required this.context});
+  LoginViewModel({required this.userModel, required this.context});
 
   final FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
   final kakao.UserApi _kakaoApi = kakao.UserApi.instance;
@@ -40,10 +42,14 @@ class LoginViewModel with ChangeNotifier {
         break;
     }
 
-    // Firebase 로그인 성공시 유저 정보 저장 및 서버에 유저 정보 요청
+    // Firebase 로그인 성공시 사용자 정보 저장 및 서버에 사용자 정보 요청
     // 토큰 저장
     // 홈으로 이동
     if (user != null) {
+      // User Model에 사용자 정보 저장
+      userModel.uid = user.uid;
+      userModel.name = user.displayName;
+
       if (context.mounted) context.go('/home');
     }
   }

--- a/lib/view_models/login_view_model.dart
+++ b/lib/view_models/login_view_model.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart' as kakao;
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
@@ -41,7 +42,10 @@ class LoginViewModel with ChangeNotifier {
 
     // Firebase 로그인 성공시 유저 정보 저장 및 서버에 유저 정보 요청
     // 토큰 저장
-    if (user != null) {}
+    // 홈으로 이동
+    if (user != null) {
+      if (context.mounted) context.go('/home');
+    }
   }
 
   /// 이메일 로그인

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -18,7 +18,7 @@ class _HomeViewState extends State<HomeView> {
       body: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Center(child: Text('asdf')),
+          Center(child: Text(homeViewModel.userModel.name ?? 'null')),
           ElevatedButton(
             onPressed: () => homeViewModel.logout(),
             child: const Text('로그아웃'),

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:nutripic/view_models/home_view_model.dart';
+import 'package:provider/provider.dart';
+
+class HomeView extends StatefulWidget {
+  const HomeView({super.key});
+
+  @override
+  State<HomeView> createState() => _HomeViewState();
+}
+
+class _HomeViewState extends State<HomeView> {
+  @override
+  Widget build(BuildContext context) {
+    HomeViewModel homeViewModel = context.watch<HomeViewModel>();
+
+    return Scaffold(
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Center(child: Text('asdf')),
+          ElevatedButton(
+            onPressed: () => homeViewModel.logout(),
+            child: const Text('로그아웃'),
+          )
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### 작업 내용

자동 로그인 유지 기능
- `firebaseAuth.instance.currentUser`를 확인하고 로그인 된 사용자를 찾는다면 유저 정보를 바로 `UserModel`에 저장하도록 했습니다.
지금은 임시로 `currentUser`의 `uid`와 `displayName`을 저장하지만, API 완성 후에는 사용자 데이터를 저장하도록 수정해야 합니다.
- `UserModel.uid`가 `null`이 아니라면 로그인된 사용자가 있다고 판단, 로그인 화면을 건너뛰고 홈 화면으로 이동하도록 했습니다.

`HomeView`, `HomeViewModel` 생성 (임시)
- 로그인 기능 테스트 위해 임시로 홈 화면 및 뷰모델 생성했습니다. 
- 로그아웃 및 아이디 확인 정도만 간단하게 구현해 두었습니다.

`UserModel` 생성
- 아직 DB 구체화가 안돼서 `uid`, `name`, `profileUrl`만 만들었습니다. DB 구체화가 되면 수정해야 합니다.
- `fromJson` : 서버에서 받아온 json 데이터를 모델에 저장시킬 때 사용
- `reset` : 로그아웃 등 기능 수행 시 모델 초기화 할 때 사용
- 사용자 모델을 서버에 보낼 일이 있을지 모르겠어서 아직 `toJson`은 안만들었습니다. 필요해지면 그때 만들 예정입니다.

API 통신시 firebase idToken을 헤더에 포함시키는 로직 구현
- `_getToken` 함수를 사용해서 API 요청 전 firebase idToken을 받아온 후 헤더에 포함시킵니다. (Authorization: Baerer)
- 각 요청 함수에 인자로 `tokenRequired = true`를 포함시켰습니다. 토큰을 포함시켜서 요청을 보낼 일이 더 많을 것 같아서 기본 값을 `true`로 설정했습니다. `false`로 설정한다면 헤더에 토큰을 포함시키지 않습니다.
- `getIdToken`을 찾아보니까 자동으로 firebase에서 만료 여부를 확인하고 유효한 토큰을 받아온다고 합니다. 그래서 따로 토큰 만료 여부를 확인하는 로직은 추가하지 않아도 될 것 같습니다.
- 만약 로그인이 되어있지 않는데 (`currentUser`가 없는데) `getIdToken()`이 호출되면 `user-not-found` 오류를 반환합니다.
추후에 에러 핸들링 기능을 추가해야 합니다. 