### PR TITLE
hotfix: 빌드시 안드로이드에서 모델이 돌아가지 않는 문제 해결

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -54,6 +54,8 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.debug
+            shrinkResources false
+            minifyEnabled false
         }
     }
 }


### PR DESCRIPTION
### 작업 내용

build.gradle 에서 모델 압축 때문에 빌드시 YOLO 모델이 제대로 작동하지 않는 문제를 수정했습니다.