### PR TITLE
design: 냉장고 컨테이너 scrollview로 변경

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -54,6 +54,8 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.debug
+            shrinkResources false
+            minifyEnabled false
         }
     }
 }

--- a/lib/components/common/bottom_navbar.dart
+++ b/lib/components/common/bottom_navbar.dart
@@ -26,11 +26,11 @@ class BottomNavbar extends StatelessWidget {
             active: 'assets/icons/record_active.svg',
             label: '기록',
           ),
-          bottomNavbarItem(
-            src: 'assets/icons/add.svg',
-            active: 'assets/icons/add_active.svg',
-            label: '식재료 추가',
-          ),
+          // bottomNavbarItem(
+          //   src: 'assets/icons/add.svg',
+          //   active: 'assets/icons/add_active.svg',
+          //   label: '식재료 추가',
+          // ),
           bottomNavbarItem(
             src: 'assets/icons/search.svg',
             active: 'assets/icons/search_active.svg',

--- a/lib/components/refrigerator/food_dday.dart
+++ b/lib/components/refrigerator/food_dday.dart
@@ -8,7 +8,7 @@ class FoodDday extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Positioned(
-      bottom: 0,
+      bottom: 1,
       child: Container(
         width: 62,
         height: 16,

--- a/lib/components/refrigerator/refrigerator_container.dart
+++ b/lib/components/refrigerator/refrigerator_container.dart
@@ -31,7 +31,7 @@ class RefrigeratorContainer extends StatelessWidget {
   Widget build(BuildContext context) {
     return Expanded(
       child: Container(
-        padding: EdgeInsets.only(bottom: 32),
+        padding: const EdgeInsets.only(bottom: 32),
         decoration: BoxDecoration(
           color: Palette.background,
           borderRadius: BorderRadius.circular(20),

--- a/lib/components/refrigerator/refrigerator_container.dart
+++ b/lib/components/refrigerator/refrigerator_container.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:nutripic/components/refrigerator/food_tile.dart';
 import 'package:nutripic/objects/food.dart';
 import 'package:nutripic/utils/palette.dart';
-import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 
 class RefrigeratorContainer extends StatelessWidget {
   /// 전체 식재료 리스트
@@ -30,12 +29,11 @@ class RefrigeratorContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    PageController controller = PageController();
-
     return Expanded(
       child: Container(
+        padding: EdgeInsets.only(bottom: 32),
         decoration: BoxDecoration(
-          color: Palette.white,
+          color: Palette.background,
           borderRadius: BorderRadius.circular(20),
           boxShadow: [Palette.shadow],
         ),
@@ -58,67 +56,29 @@ class RefrigeratorContainer extends StatelessWidget {
                 ),
               )
             // 식재료 리스트가 있으면 GridView 생성
-            : Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Expanded(
-                    child: PageView.builder(
-                      controller: controller,
-                      physics: const ClampingScrollPhysics(),
-                      itemCount: (foods.length / 9).ceil(),
-                      itemBuilder: (context, pageIndex) {
-                        // 현제 페이지의 시작 index
-                        final int startIndex = pageIndex * 9;
-                        // 현제 페이지의 마지막 식재료 index
-                        // foods.length가 최대 크기
-                        final int endIndex =
-                            (startIndex + 9).clamp(0, foods.length);
-
-                        return GridView.builder(
-                          itemCount: endIndex - startIndex,
-                          padding: const EdgeInsets.symmetric(
-                            vertical: 30,
-                            horizontal: 10,
-                          ),
-                          physics: const NeverScrollableScrollPhysics(),
-                          gridDelegate:
-                              const SliverGridDelegateWithFixedCrossAxisCount(
-                            mainAxisSpacing: 24,
-                            crossAxisSpacing: 22,
-                            crossAxisCount: 4,
-                            childAspectRatio: 64 / 84,
-                          ),
-                          itemBuilder: (context, gridIndex) {
-                            // 식재료 최종 index
-                            final foodIndex = startIndex + gridIndex;
-
-                            return FoodTile(
-                              food: foods[foodIndex],
-                              isSelected:
-                                  selectedFoods.contains(foods[foodIndex]),
-                              isSelectable: isSelectable,
-                              showDday: foods[foodIndex].showDday(),
-                              select: selectFood,
-                            );
-                          },
-                        );
-                      },
-                    ),
-                  ),
-
-                  // 페이지 indicator
-                  SmoothPageIndicator(
-                    controller: controller,
-                    count: (foods.length / 9).ceil(),
-                    effect: const WormEffect(
-                      dotWidth: 5,
-                      dotHeight: 5,
-                      dotColor: Palette.gray100,
-                      activeDotColor: Palette.sub,
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                ],
+            : GridView.builder(
+                shrinkWrap: true,
+                itemCount: foods.length,
+                padding: const EdgeInsets.symmetric(
+                  vertical: 30,
+                  horizontal: 10,
+                ),
+                physics: const BouncingScrollPhysics(),
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  mainAxisSpacing: 24,
+                  crossAxisSpacing: 22,
+                  crossAxisCount: 4,
+                  childAspectRatio: 64 / 84,
+                ),
+                itemBuilder: (context, foodIndex) {
+                  return FoodTile(
+                    food: foods[foodIndex],
+                    isSelected: selectedFoods.contains(foods[foodIndex]),
+                    isSelectable: isSelectable,
+                    showDday: foods[foodIndex].showDday(),
+                    select: selectFood,
+                  );
+                },
               ),
       ),
     );

--- a/lib/utils/app_router.dart
+++ b/lib/utils/app_router.dart
@@ -167,20 +167,20 @@ class AppRouter {
             ),
 
             // 카메라
-            StatefulShellBranch(
-              routes: [
-                GoRoute(
-                  path: '/camera',
-                  builder: (context, state) => ChangeNotifierProvider(
-                    create: (context) => CameraViewModel(
-                      refrigeratorModel: refrigeratorModel,
-                      context: context,
-                    ),
-                    child: const CameraView(),
-                  ),
-                ),
-              ],
-            ),
+            // StatefulShellBranch(
+            //   routes: [
+            //     GoRoute(
+            //       path: '/camera',
+            //       builder: (context, state) => ChangeNotifierProvider(
+            //         create: (context) => CameraViewModel(
+            //           refrigeratorModel: refrigeratorModel,
+            //           context: context,
+            //         ),
+            //         child: const CameraView(),
+            //       ),
+            //     ),
+            //   ],
+            // ),
 
             // 레시피
             StatefulShellBranch(

--- a/lib/view_models/refrigerator/refrigerator_view_model.dart
+++ b/lib/view_models/refrigerator/refrigerator_view_model.dart
@@ -11,7 +11,63 @@ class RefrigeratorViewModel with ChangeNotifier {
   RefrigeratorViewModel({
     required this.refrigeratorModel,
     required this.context,
-  });
+  }) {
+    Food food = Food(
+        id: 0,
+        name: '당근',
+        icon: 'carrot',
+        class1: 'class1',
+        class2: 'class2',
+        addedDate: DateTime.now(),
+        expireDate: DateTime.now(),
+        expired: false);
+
+    refrigeratorModel.foods = [
+      [
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+      ],
+      [
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+        food,
+      ],
+      []
+    ];
+  }
 
   /// 현재 선택된 냉장고
   StorageType storage = StorageType.fridge;

--- a/lib/views/refrigerator/refrigerator_view.dart
+++ b/lib/views/refrigerator/refrigerator_view.dart
@@ -19,65 +19,76 @@ class RefrigeratorView extends StatelessWidget {
 
     return CustomScaffold(
       appBar: const CustomAppBar(backButton: false),
-      body: Column(
-        mainAxisSize: MainAxisSize.min,
+      body: Stack(
+        alignment: Alignment.bottomCenter,
         children: [
-          const SizedBox(height: 26),
-
-          // 헤더
-          Row(
+          Column(
+            mainAxisSize: MainAxisSize.min,
             children: [
-              const Text('나의 냉장고', style: Palette.heading),
-              const Spacer(),
-              IconButton(
-                onPressed: refrigeratorViewModel.onTapCamera,
-                icon: const Icon(
-                  Icons.camera,
-                ),
+              const SizedBox(height: 26),
+
+              // 헤더
+              Row(
+                children: [
+                  const Text('나의 냉장고', style: Palette.heading),
+                  const Spacer(),
+                  IconButton(
+                    onPressed: refrigeratorViewModel.onTapCamera,
+                    icon: const Icon(
+                      Icons.camera,
+                    ),
+                  ),
+                  refrigeratorViewModel.isSelectable
+                      // 취소 버튼
+                      ? SelectButton(
+                          label: '취소',
+                          type: SelectButtonType.cancel,
+                          onPressed: refrigeratorViewModel.onTapCancel,
+                        )
+                      // 정렬
+                      : const Text('추가한 순', style: Palette.body),
+                  const SizedBox(width: 15),
+                  refrigeratorViewModel.isSelectable
+                      // 삭제 버튼
+                      ? SelectButton(
+                          label: '삭제',
+                          type: SelectButtonType.delete,
+                          onPressed: refrigeratorViewModel.onTapDelete,
+                        )
+                      // 선택 버튼
+                      : SelectButton(
+                          label: '선택',
+                          onPressed: refrigeratorViewModel.onTapSelect)
+                ],
               ),
-              refrigeratorViewModel.isSelectable
-                  // 취소 버튼
-                  ? SelectButton(
-                      label: '취소',
-                      type: SelectButtonType.cancel,
-                      onPressed: refrigeratorViewModel.onTapCancel,
-                    )
-                  // 정렬
-                  : const Text('추가한 순', style: Palette.body),
-              const SizedBox(width: 15),
-              refrigeratorViewModel.isSelectable
-                  // 삭제 버튼
-                  ? SelectButton(
-                      label: '삭제',
-                      type: SelectButtonType.delete,
-                      onPressed: refrigeratorViewModel.onTapDelete,
-                    )
-                  // 선택 버튼
-                  : SelectButton(
-                      label: '선택', onPressed: refrigeratorViewModel.onTapSelect)
+              const SizedBox(height: 12),
+
+              // 냉장고
+              RefrigeratorContainer(
+                foods: refrigeratorViewModel.refrigeratorModel
+                    .foods[refrigeratorViewModel.storage.rawValue],
+                selectedFoods: refrigeratorViewModel.selectedFoods,
+                isSelectable: refrigeratorViewModel.isSelectable,
+                addFood: null,
+                selectFood: refrigeratorViewModel.selectFood,
+              ),
+              const SizedBox(height: 16),
             ],
           ),
-          const SizedBox(height: 12),
-
-          // 냉장고
-          RefrigeratorContainer(
-            foods: refrigeratorViewModel.refrigeratorModel
-                .foods[refrigeratorViewModel.storage.rawValue],
-            selectedFoods: refrigeratorViewModel.selectedFoods,
-            isSelectable: refrigeratorViewModel.isSelectable,
-            addFood: null,
-            selectFood: refrigeratorViewModel.selectFood,
-          ),
-          const SizedBox(height: 15),
 
           // 냉장고 선택 버튼
-          RefrigeratorSelectContainer(
-            selected: refrigeratorViewModel.storage,
-            onTapRefrigerator: refrigeratorViewModel.onTapRefrigerator,
-            onTapFreezer: refrigeratorViewModel.onTapFreezer,
-            onTapCabinet: refrigeratorViewModel.onTapCabinet,
-          ),
-          const SizedBox(height: 34),
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              RefrigeratorSelectContainer(
+                selected: refrigeratorViewModel.storage,
+                onTapRefrigerator: refrigeratorViewModel.onTapRefrigerator,
+                onTapFreezer: refrigeratorViewModel.onTapFreezer,
+                onTapCabinet: refrigeratorViewModel.onTapCabinet,
+              ),
+              const SizedBox(height: 24),
+            ],
+          )
         ],
       ),
     );


### PR DESCRIPTION
### 작업 내용
냉장고 컨테이너를 좌우 스와이프에서 스크롤 뷰로 바꿨습니다.  
냉장고 변경 버튼을 스택으로 컨테이너 위에 띄웠습니다.

하단 네비게이션 바에서 카메라 탭 제거했습니다.

### 이슈
화면 전체를 스크롤하게 하고싶었는데, 식재료가 부족하면 컨테이너가 그만큼 축소되는 상황이 발생했습니다.  
식재료가 부족해도 최소 높이로 화면 높이만큼 채워야하는데, 이게 잘 안되서 일단 포기하고 그냥 컨테이너 내에서 스크롤하도록 구현했습니다.

<img width=250 src=https://github.com/user-attachments/assets/a0476e04-2cb6-4822-9196-47e3cd242076 />
