### PR TITLE
feature: 분석중 로딩 화면 구현

### DIFF
--- a/lib/components/common/custom_app_bar.dart
+++ b/lib/components/common/custom_app_bar.dart
@@ -1,43 +1,79 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nutripic/utils/palette.dart';
 
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  /// 제목
   final String? title;
+
+  /// 제목 위젯
   final Widget? titleWidget;
+
+  /// 제목 중앙 정렬 여부
   final bool centerTitle;
+
+  /// 뒤로가기 버튼 표시 여부
   final bool backButton;
+
+  /// 하단 구분선 표시 여부
+  final bool underLine;
+
+  /// 우측 표시 위젯
   final List<Widget>? actions;
 
   /// ### AppBar에서 필요한 기능들을 적용한 위젯
   /// `title` : AppBar 타이틀
   ///
+  /// `titleWidget` : `title` 대신 사용하는 위젯
+  /// - `title`이 `null`인 경우 적용 가능
+  ///
+  /// `centerTitle` : 타이틀 중앙 정렬 여부
+  /// - `false`인 경우 우측에 표시
+  ///
   /// `backBtn` : 뒤로가기 버튼 표시 여부
   /// - 뒤로가기 버튼이 표시되는 경우가 더 많아서 기본 값은 `true`로 설정
+  ///
+  /// `underLine` : 하단 구분선 표시 여부
+  /// - 기본 값은 `true`로 설정
+  ///
+  /// `actions` : 앱바 우측에 표시되는 위젯 리스트
   const CustomAppBar({
     super.key,
     this.title,
     this.titleWidget,
     this.centerTitle = true,
     this.backButton = true,
+    this.underLine = true,
     this.actions,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: AppBar(
-        title: title != null ? Text(title!) : titleWidget,
-        centerTitle: centerTitle,
-        leadingWidth: 32,
-        leading: backButton
-            ? IconButton(
+    return AppBar(
+      title: title != null ? Text(title!) : titleWidget,
+      centerTitle: centerTitle,
+      leadingWidth: 32,
+      leading: backButton
+          ? Padding(
+              padding: const EdgeInsets.only(left: 16),
+              child: IconButton(
                 onPressed: () => context.pop(),
                 icon: const Icon(Icons.arrow_back_ios, size: 24),
-              )
-            : null,
-        actions: actions,
-      ),
+              ),
+            )
+          : null,
+      actions: [
+        ...?actions,
+        const Padding(padding: EdgeInsets.only(right: 16)),
+      ],
+      shape: underLine
+          ? const Border(
+              bottom: BorderSide(
+                color: Palette.gray100,
+                width: 1,
+              ),
+            )
+          : null,
     );
   }
 

--- a/lib/utils/app_router.dart
+++ b/lib/utils/app_router.dart
@@ -8,6 +8,7 @@ import 'package:nutripic/models/refrigerator_model.dart';
 import 'package:nutripic/models/user_model.dart';
 import 'package:nutripic/view_models/camera/camera_add_view_model.dart';
 import 'package:nutripic/view_models/camera/camera_confirm_view_model.dart';
+import 'package:nutripic/view_models/camera/camera_loading_view_model.dart';
 import 'package:nutripic/view_models/camera/camera_view_model.dart';
 import 'package:nutripic/view_models/diary/diary_post_view_model.dart';
 import 'package:nutripic/view_models/diary/diary_record_view_model.dart';
@@ -23,6 +24,7 @@ import 'package:nutripic/view_models/user_info/user_edit_view_model.dart';
 import 'package:nutripic/view_models/user_info/user_info_view_model.dart';
 import 'package:nutripic/views/camera/camera_add_view.dart';
 import 'package:nutripic/views/camera/camera_confirm_view.dart';
+import 'package:nutripic/views/camera/camera_loading_view.dart';
 import 'package:nutripic/views/diary/diary_record_view.dart';
 import 'package:nutripic/views/diary/diary_view.dart';
 import 'package:nutripic/views/login/email_view.dart';
@@ -137,6 +139,7 @@ class AppRouter {
                     child: const RefrigeratorView(),
                   ),
                   routes: [
+                    // 카메라 사진 촬영
                     GoRoute(
                       path: 'camera',
                       parentNavigatorKey: _rootNavigatorKey,
@@ -149,6 +152,7 @@ class AppRouter {
                         child: const CameraView(),
                       ),
                       routes: [
+                        // 사진 확인
                         GoRoute(
                           path: 'confirm',
                           parentNavigatorKey: _rootNavigatorKey,
@@ -162,6 +166,19 @@ class AppRouter {
                         )
                       ],
                     ),
+                    // 분석 중 로딩 화면
+                    GoRoute(
+                      path: 'loading',
+                      parentNavigatorKey: _rootNavigatorKey,
+                      builder: (context, state) => ChangeNotifierProvider(
+                        create: (context) => CameraLoadingViewModel(
+                          cameraModel: cameraModel,
+                          context: context,
+                        ),
+                        child: const CameraLoadingView(),
+                      ),
+                    ),
+                    // 식재료 추가
                     GoRoute(
                       path: 'add',
                       parentNavigatorKey: _rootNavigatorKey,

--- a/lib/view_models/camera/camera_confirm_view_model.dart
+++ b/lib/view_models/camera/camera_confirm_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:nutripic/models/camera_model.dart';
 
 class CameraConfirmViewModel with ChangeNotifier {
@@ -11,6 +12,9 @@ class CameraConfirmViewModel with ChangeNotifier {
 
   /// 이미지 선택 활성화
   bool isSelectable = false;
+
+  /// 분석하기 버튼 활성화
+  bool isAnalyzeBtnEnabled = true;
 
   /// 선택 버튼 클릭
   void onTapSelect() {
@@ -34,6 +38,8 @@ class CameraConfirmViewModel with ChangeNotifier {
     cameraModel.removeImages();
 
     // 선택 종료
+    // 이미지를 모두 지웠다면 버튼 비활성화
+    isAnalyzeBtnEnabled = cameraModel.images.isNotEmpty;
     isSelectable = false;
     notifyListeners();
   }
@@ -58,7 +64,12 @@ class CameraConfirmViewModel with ChangeNotifier {
 
   /// 이미지 분석
   void onTapSend() {
-    // 카메라 컨트롤러 제거
-    cameraModel.controller?.dispose();
+    // 분석할 이미지가 있을 때만 작동
+    if (cameraModel.images.isNotEmpty) {
+      // 카메라 컨트롤러 제거
+      cameraModel.controller?.dispose();
+
+      context.go('/refrigerator/loading');
+    }
   }
 }

--- a/lib/view_models/camera/camera_loading_view_model.dart
+++ b/lib/view_models/camera/camera_loading_view_model.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+import 'package:nutripic/models/camera_model.dart';
+
+class CameraLoadingViewModel with ChangeNotifier {
+  CameraModel cameraModel;
+  BuildContext context;
+
+  CameraLoadingViewModel({required this.cameraModel, required this.context});
+}

--- a/lib/views/camera/camera_confirm_view.dart
+++ b/lib/views/camera/camera_confirm_view.dart
@@ -5,6 +5,7 @@ import 'package:nutripic/components/common/custom_scaffold.dart';
 import 'package:nutripic/components/main_button.dart';
 import 'package:nutripic/components/box_button.dart';
 import 'package:nutripic/utils/enums/box_button_type.dart';
+import 'package:nutripic/utils/enums/main_button_type.dart';
 import 'package:nutripic/view_models/camera/camera_confirm_view_model.dart';
 import 'package:provider/provider.dart';
 
@@ -57,6 +58,9 @@ class CameraConfirmView extends StatelessWidget {
           // 분석 버튼
           MainButton(
             label: '분석하기',
+            type: cameraConfirmViewModel.isAnalyzeBtnEnabled
+                ? MainButtonType.enabled
+                : MainButtonType.disabled,
             onPressed: cameraConfirmViewModel.onTapSend,
           ),
         ],

--- a/lib/views/camera/camera_loading_view.dart
+++ b/lib/views/camera/camera_loading_view.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:nutripic/components/common/custom_scaffold.dart';
+import 'package:nutripic/utils/palette.dart';
+
+class CameraLoadingView extends StatelessWidget {
+  const CameraLoadingView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScaffold(
+      canPop: false,
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            // 텍스트
+            Text('분석 중입니다',
+                style: Palette.title2Medium.copyWith(
+                  color: Palette.green600,
+                )),
+            const SizedBox(height: 20),
+
+            // 로딩
+            const SizedBox(
+              width: 36,
+              height: 36,
+              child: CircularProgressIndicator(
+                color: Palette.gray200,
+                backgroundColor: Palette.gray100,
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 📝작업 내용
이미지 촬영 후 분석 로딩 화면 구현했습니다.
- API 수정이 필요한 상태라 로직은 구현 못하고 UI만 우선 만들었습니다.

이미지 확인 페이지에서 분석 로딩 화면으로 이동할 수 있도록 로직 수정했습니다.
- 이미지를 모두 삭제했다면 버튼이 비활성화되고 이동이 불가능하게 수정했습니다.

`CustomAppBar`에 하단 구분선 추가했습니다.
- 기본 값은 `true`로 설정했습니다.

## 스크린샷
<img src="https://github.com/user-attachments/assets/d5f188d1-2fae-4efc-9365-175c27048469" width="200" />
