### PR TITLE
feature: camera api

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '16.6'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -498,7 +498,7 @@
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "뉴트리픽";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -689,7 +689,7 @@
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "뉴트리픽";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -720,7 +720,7 @@
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "뉴트리픽";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/lib/components/box_button.dart
+++ b/lib/components/box_button.dart
@@ -27,7 +27,7 @@ class BoxButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: s ? 56 : 64,
+      width: s ? 56 : 80,
       height: s ? 32 : 36,
       child: FilledButton(
         onPressed: onPressed,

--- a/lib/components/camera/food_add_container.dart
+++ b/lib/components/camera/food_add_container.dart
@@ -1,52 +1,60 @@
 import 'package:flutter/material.dart';
 import 'package:nutripic/components/camera/recognized_food_tile.dart';
+import 'package:nutripic/objects/food.dart';
 import 'package:nutripic/utils/palette.dart';
 
 class FoodAddContainer extends StatelessWidget {
-  final Set<String> recognizedFoods;
-  const FoodAddContainer({super.key, required this.recognizedFoods});
+  final String title;
+  final List<Food> recognizedFoods;
+  final bool isSelectState;
+  const FoodAddContainer({
+    super.key,
+    required this.title,
+    required this.recognizedFoods,
+    required this.isSelectState,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        const SizedBox(height: 36),
+    return recognizedFoods.isNotEmpty
+        ? Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // 타이틀
+              Text(title, style: Palette.title1Medium),
+              const SizedBox(height: 16),
 
-        // 타이틀
-        Row(
-          children: [
-            const Text('냉장보관', style: Palette.title1Medium),
-            const Spacer(),
-            IconButton(onPressed: () {}, icon: const Icon(Icons.add_rounded))
-          ],
-        ),
-        const SizedBox(height: 16),
+              // 인식한 식재료 컨테이너
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: Palette.gray00,
+                  border: Border.all(color: Palette.gray200),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: ListView.separated(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: recognizedFoods.length,
+                  separatorBuilder: (context, index) => const Divider(
+                    color: Palette.gray100,
+                    height: 12,
+                  ),
+                  itemBuilder: (BuildContext context, int index) =>
+                      RecognizedFoodTile(
+                    food: recognizedFoods.elementAt(index),
+                    isSelectState: isSelectState,
+                    onTapEdit: () {},
+                  ),
+                ),
+              ),
 
-        // 인식한 식재료 컨테이너
-        Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(8),
-          decoration: BoxDecoration(
-            color: Palette.gray00,
-            border: Border.all(color: Palette.gray200),
-            borderRadius: BorderRadius.circular(16),
-          ),
-          child: ListView.separated(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            itemCount: recognizedFoods.length,
-            separatorBuilder: (context, index) => const SizedBox(height: 8),
-            itemBuilder: (BuildContext context, int index) =>
-                RecognizedFoodTile(
-              name: recognizedFoods.elementAt(index),
-              onTapEdit: () {},
-              onTapDelete: () {},
-            ),
-          ),
-        ),
-      ],
-    );
+              const SizedBox(height: 32),
+            ],
+          )
+        : Container();
   }
 }

--- a/lib/components/camera/image_confirm_select.dart
+++ b/lib/components/camera/image_confirm_select.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:nutripic/utils/palette.dart';
+import 'package:nutripic/components/refrigerator/icon_selection.dart';
+import 'package:nutripic/utils/enums/icon_selection_type.dart';
 
 class ImageConfirmSelect extends StatelessWidget {
   final bool isSelected;
@@ -10,20 +11,9 @@ class ImageConfirmSelect extends StatelessWidget {
     return Positioned(
       top: 6,
       right: 6,
-      child: Container(
-        width: 24,
-        height: 24,
-        decoration: BoxDecoration(
-          color: isSelected ? Palette.green400 : Palette.gray100,
-          shape: BoxShape.circle,
-          border: Border.all(
-            color: Palette.gray00,
-            width: 2,
-          ),
-        ),
-        child: isSelected
-            ? const Icon(Icons.check_rounded, color: Palette.gray00, size: 14)
-            : Container(),
+      child: IconSelection(
+        isSelected: isSelected,
+        type: IconSelectionType.large,
       ),
     );
   }

--- a/lib/components/camera/recognized_food_tile.dart
+++ b/lib/components/camera/recognized_food_tile.dart
@@ -1,18 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:nutripic/components/image_button.dart';
+import 'package:nutripic/components/refrigerator/icon_selection.dart';
+import 'package:nutripic/objects/food.dart';
 import 'package:nutripic/utils/palette.dart';
 
 class RecognizedFoodTile extends StatelessWidget {
-  final String name;
+  /// 인식된 식재료
+  final Food food;
+
+  /// 선택 모드
+  final bool isSelectState;
+
+  /// 수정 버튼 클릭시 호출할 함수
   final Function()? onTapEdit;
-  final Function()? onTapDelete;
 
   /// `name = filename.svg`
   const RecognizedFoodTile({
     super.key,
-    required this.name,
+    required this.food,
+    required this.isSelectState,
     required this.onTapEdit,
-    required this.onTapDelete,
   });
 
   @override
@@ -20,14 +28,22 @@ class RecognizedFoodTile extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
+        // 선택 버튼
+        if (isSelectState) const IconSelection(isSelected: false),
+        if (isSelectState) const SizedBox(width: 8),
+
         // 식재료 이미지
         Container(
           width: 56,
           height: 56,
           decoration: BoxDecoration(
-            color: Palette.gray100,
-            borderRadius: BorderRadius.circular(10),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: Palette.gray200,
+              width: 1,
+            ),
           ),
+          child: SvgPicture.asset('assets/foods/${food.icon}.svg'),
         ),
         const SizedBox(width: 16),
 
@@ -35,16 +51,26 @@ class RecognizedFoodTile extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // 유통기한
-            Text(
-              'D-5',
-              style: Palette.subbody1.copyWith(
+            Container(
+              width: 45,
+              height: 22,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
                 color: Palette.delete,
-                fontWeight: FontWeight.w500,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Text(
+                'D-5',
+                style: Palette.caption1.copyWith(color: Palette.gray00),
               ),
             ),
+            const SizedBox(height: 6),
 
             // 식재료 이름
-            Text(name, style: Palette.title1Medium),
+            Text(
+              food.name,
+              style: Palette.body1.copyWith(color: Palette.gray900),
+            ),
           ],
         ),
 
@@ -56,15 +82,6 @@ class RecognizedFoodTile extends StatelessWidget {
           width: 24,
           height: 24,
           onTap: onTapEdit,
-        ),
-        const SizedBox(width: 24),
-
-        // 삭제 버튼
-        ImageButton(
-          img: '/trash.svg',
-          width: 24,
-          height: 24,
-          onTap: onTapDelete,
         ),
       ],
     );

--- a/lib/components/refrigerator/food_select.dart
+++ b/lib/components/refrigerator/food_select.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:nutripic/utils/palette.dart';
+import 'package:nutripic/components/refrigerator/icon_selection.dart';
 
 class FoodSelect extends StatelessWidget {
   final bool isSelected;
@@ -10,21 +10,7 @@ class FoodSelect extends StatelessWidget {
     return Positioned(
       top: 4,
       left: 4,
-      child: Container(
-        width: 16,
-        height: 16,
-        decoration: BoxDecoration(
-          color: isSelected ? Palette.green400 : Palette.gray00,
-          shape: BoxShape.circle,
-          border: Border.all(
-            color: isSelected ? Palette.green400 : Palette.gray100,
-            width: 1,
-          ),
-        ),
-        child: isSelected
-            ? const Icon(Icons.check_rounded, color: Palette.gray00, size: 12)
-            : Container(),
-      ),
+      child: IconSelection(isSelected: isSelected),
     );
   }
 }

--- a/lib/components/refrigerator/food_tile.dart
+++ b/lib/components/refrigerator/food_tile.dart
@@ -49,7 +49,7 @@ class FoodTile extends StatelessWidget {
                           ? Palette.green400
                           : food.expired && !isSelectable
                               ? Palette.delete
-                              : Palette.gray100,
+                              : Palette.gray200,
                       width: 1,
                     ),
                   ),

--- a/lib/components/refrigerator/icon_selection.dart
+++ b/lib/components/refrigerator/icon_selection.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:nutripic/utils/enums/icon_selection_type.dart';
+import 'package:nutripic/utils/palette.dart';
+
+class IconSelection extends StatelessWidget {
+  final bool isSelected;
+  final IconSelectionType type;
+
+  const IconSelection({
+    super.key,
+    required this.isSelected,
+    this.type = IconSelectionType.small,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: type.size,
+      height: type.size,
+      decoration: BoxDecoration(
+        color: isSelected ? type.activeFillColor : type.inactiveFillColor,
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: isSelected ? type.activeStrokeColor : type.inactiveStrokeColor,
+          width: type.strokeWidth,
+        ),
+      ),
+      child: isSelected
+          ? const Icon(Icons.check_rounded, color: Palette.gray00, size: 12)
+          : Container(),
+    );
+  }
+}

--- a/lib/models/camera_model.dart
+++ b/lib/models/camera_model.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:nutripic/objects/food.dart';
+import 'package:nutripic/utils/api.dart';
 
 class CameraModel with ChangeNotifier {
   /// 카메라 촬영을 위한 컨트롤러
@@ -15,6 +17,9 @@ class CameraModel with ChangeNotifier {
 
   /// 선택된 이미지
   List<int> selectedImages = [];
+
+  /// GPT 인식한 식재료
+  List<List<Food>> analyzedFoods = [[], [], []];
 
   CameraModel({this.controller});
 
@@ -36,6 +41,9 @@ class CameraModel with ChangeNotifier {
 
     // 선택된 이미지 인덱스 초기화
     selectedImages.clear();
+
+    // 인식한 식재료 초기화
+    analyzedFoods = [[], [], []];
   }
 
   /// 카메라 로드
@@ -100,5 +108,10 @@ class CameraModel with ChangeNotifier {
 
     // 선택된 이미지 초기화
     selectedImages.clear();
+  }
+
+  /// 사진 전송 후 GPT 인식한 식재료 가져오는 함수
+  Future<void> getAnalyzedImages() async {
+    analyzedFoods = await API.postImageToFood(images.first);
   }
 }

--- a/lib/objects/food.dart
+++ b/lib/objects/food.dart
@@ -37,9 +37,9 @@ class Food {
   /// jsonData에서 받아온 데이터를 Food로 변환 저장하는 함수
   factory Food.fromJson(Map<String, dynamic> json) {
     return Food(
-      id: json['id'],
+      id: json['id'] ?? 0,
       name: json['name'],
-      icon: json['icon'],
+      icon: json['icon'] ?? 'carrot',
       class1: json['class1'],
       class2: json['class2'],
       addedDate: DateTime.parse(json['addedDate']),

--- a/lib/utils/app_router.dart
+++ b/lib/utils/app_router.dart
@@ -188,6 +188,7 @@ class AppRouter {
                       builder: (context, state) => ChangeNotifierProvider(
                         create: (context) => CameraAddViewModel(
                           refrigeratorModel: refrigeratorModel,
+                          cameraModel: cameraModel,
                           context: context,
                         ),
                         child: const CameraAddView(),

--- a/lib/utils/enums/box_button_type.dart
+++ b/lib/utils/enums/box_button_type.dart
@@ -5,7 +5,8 @@ import 'package:nutripic/utils/palette.dart';
 enum BoxButtonType {
   normal(Palette.gray600, Palette.gray100),
   transparent(Palette.gray00, Colors.transparent),
-  delete(Palette.gray00, Palette.delete);
+  delete(Palette.gray00, Palette.delete),
+  primary(Palette.green600, Palette.gray100);
 
   final Color color;
   final Color backgroundColor;

--- a/lib/utils/enums/icon_selection_type.dart
+++ b/lib/utils/enums/icon_selection_type.dart
@@ -1,0 +1,39 @@
+import 'dart:ui';
+
+import 'package:flutter/rendering.dart';
+import 'package:nutripic/utils/palette.dart';
+
+/// Main Button 타입
+enum IconSelectionType {
+  small(
+    size: 18,
+    strokeWidth: 1,
+    activeStrokeColor: Palette.green400,
+    inactiveStrokeColor: Palette.gray200,
+    activeFillColor: Palette.green400,
+    inactiveFillColor: Palette.gray00,
+  ),
+  large(
+    size: 22,
+    strokeWidth: 2,
+    activeStrokeColor: Palette.gray00,
+    inactiveStrokeColor: Palette.gray00,
+    activeFillColor: Palette.green400,
+    inactiveFillColor: Palette.gray100,
+  );
+
+  final double size;
+  final double strokeWidth;
+  final Color activeStrokeColor;
+  final Color inactiveStrokeColor;
+  final Color activeFillColor;
+  final Color inactiveFillColor;
+  const IconSelectionType({
+    required this.size,
+    required this.strokeWidth,
+    required this.activeStrokeColor,
+    required this.inactiveStrokeColor,
+    required this.activeFillColor,
+    required this.inactiveFillColor,
+  });
+}

--- a/lib/utils/enums/main_button_type.dart
+++ b/lib/utils/enums/main_button_type.dart
@@ -5,7 +5,8 @@ import 'package:nutripic/utils/palette.dart';
 /// Main Button 타입
 enum MainButtonType {
   enabled(color: Palette.green500, textColor: Palette.gray00),
-  disabled(color: Palette.gray200, textColor: Palette.gray400);
+  disabled(color: Palette.gray200, textColor: Palette.gray400),
+  delete(color: Palette.delete, textColor: Palette.gray00);
 
   final Color color;
   final Color textColor;

--- a/lib/view_models/camera/camera_add_view_model.dart
+++ b/lib/view_models/camera/camera_add_view_model.dart
@@ -1,14 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nutripic/models/camera_model.dart';
 import 'package:nutripic/models/refrigerator_model.dart';
 import 'package:nutripic/utils/api.dart';
 
 class CameraAddViewModel with ChangeNotifier {
   RefrigeratorModel refrigeratorModel;
+  CameraModel cameraModel;
   BuildContext context;
-  CameraAddViewModel({required this.refrigeratorModel, required this.context});
+  CameraAddViewModel({
+    required this.refrigeratorModel,
+    required this.cameraModel,
+    required this.context,
+  });
 
   bool isLoading = false;
+
+  bool isSelectState = false;
+
+  void onPressSelect() {
+    isSelectState = !isSelectState;
+    notifyListeners();
+  }
 
   void onPressedSave() async {
     isLoading = true;

--- a/lib/view_models/camera/camera_loading_view_model.dart
+++ b/lib/view_models/camera/camera_loading_view_model.dart
@@ -1,9 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:nutripic/models/camera_model.dart';
 
 class CameraLoadingViewModel with ChangeNotifier {
   CameraModel cameraModel;
   BuildContext context;
 
-  CameraLoadingViewModel({required this.cameraModel, required this.context});
+  CameraLoadingViewModel({required this.cameraModel, required this.context}) {
+    analyzeImage();
+  }
+
+  /// 이미지 전송 후 GPT 인식한 식재료를 모델에 저장하는 함수
+  void analyzeImage() async {
+    // 이미지 분석
+    await cameraModel.getAnalyzedImages();
+
+    // 이미지 저장 후 최종 확인 페이지로 이동
+    if (context.mounted) context.go('/refrigerator/add');
+  }
 }

--- a/lib/views/camera/camera_add_view.dart
+++ b/lib/views/camera/camera_add_view.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:nutripic/components/box_button.dart';
 import 'package:nutripic/components/camera/food_add_container.dart';
 import 'package:nutripic/components/common/custom_app_bar.dart';
 import 'package:nutripic/components/common/custom_scaffold.dart';
 import 'package:nutripic/components/main_button.dart';
+import 'package:nutripic/utils/enums/box_button_type.dart';
+import 'package:nutripic/utils/enums/main_button_type.dart';
+import 'package:nutripic/utils/palette.dart';
 import 'package:nutripic/view_models/camera/camera_add_view_model.dart';
 import 'package:provider/provider.dart';
 
@@ -14,24 +18,94 @@ class CameraAddView extends StatelessWidget {
     CameraAddViewModel cameraAddViewModel = context.watch<CameraAddViewModel>();
 
     return CustomScaffold(
-      appBar: const CustomAppBar(title: '분석 결과'),
-      isLoading: cameraAddViewModel.isLoading,
-      body: SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // 인식된 식재료 리스트
-            const FoodAddContainer(recognizedFoods: {}),
-            const SizedBox(height: 32),
-
-            // 보관 버튼
-            MainButton(
-              label: '보관하기',
-              onPressed: cameraAddViewModel.onPressedSave,
-            ),
-          ],
-        ),
+      appBar: CustomAppBar(
+        title: '분석 결과',
+        actions: [
+          BoxButton(
+              label: cameraAddViewModel.isSelectState ? '취소' : '선택',
+              onPressed: cameraAddViewModel.onPressSelect),
+        ],
       ),
+      isLoading: cameraAddViewModel.isLoading,
+      body: CustomScrollView(
+        shrinkWrap: true,
+        physics: const BouncingScrollPhysics(),
+        slivers: [
+          SliverList(
+            delegate: SliverChildListDelegate(
+              [
+                const SizedBox(height: 32),
+
+                // 인식된 식재료 리스트
+                FoodAddContainer(
+                  title: '냉장보관',
+                  recognizedFoods:
+                      cameraAddViewModel.cameraModel.analyzedFoods[0],
+                  isSelectState: cameraAddViewModel.isSelectState,
+                ),
+
+                // 인식된 식재료 리스트
+                FoodAddContainer(
+                  title: '냉동보관',
+                  recognizedFoods:
+                      cameraAddViewModel.cameraModel.analyzedFoods[1],
+                  isSelectState: cameraAddViewModel.isSelectState,
+                ),
+
+                // 인식된 식재료 리스트
+                FoodAddContainer(
+                  title: '실온보관',
+                  recognizedFoods:
+                      cameraAddViewModel.cameraModel.analyzedFoods[2],
+                  isSelectState: cameraAddViewModel.isSelectState,
+                ),
+              ],
+            ),
+          ),
+
+          // Spacer로 하단 분리
+          SliverFillRemaining(
+            hasScrollBody: false,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const Spacer(),
+
+                // 식재료 등록 문구
+                if (!cameraAddViewModel.isSelectState)
+                  Text(
+                    '찾는 재료가 없다면, 식재료를 새로 등록해보세요.',
+                    style: Palette.caption2.copyWith(color: Palette.gray400),
+                  ),
+                if (!cameraAddViewModel.isSelectState)
+                  const SizedBox(height: 20),
+
+                // 새 식재료 등록 버튼
+                if (!cameraAddViewModel.isSelectState)
+                  BoxButton(
+                    label: '등록하기',
+                    type: BoxButtonType.primary,
+                    s: false,
+                    onPressed: () {},
+                  ),
+                if (!cameraAddViewModel.isSelectState)
+                  const SizedBox(height: 40),
+
+                // 보관 버튼
+                MainButton(
+                  label: cameraAddViewModel.isSelectState ? '삭제하기' : '보관하기',
+                  type: cameraAddViewModel.isSelectState
+                      ? MainButtonType.delete
+                      : MainButtonType.enabled,
+                  onPressed: cameraAddViewModel.onPressedSave,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      // ),
     );
   }
 }

--- a/lib/views/camera/camera_loading_view.dart
+++ b/lib/views/camera/camera_loading_view.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:nutripic/components/common/custom_scaffold.dart';
 import 'package:nutripic/utils/palette.dart';
+import 'package:nutripic/view_models/camera/camera_loading_view_model.dart';
+import 'package:provider/provider.dart';
 
 class CameraLoadingView extends StatelessWidget {
   const CameraLoadingView({super.key});
 
   @override
   Widget build(BuildContext context) {
+    context.watch<CameraLoadingViewModel>();
+
     return CustomScaffold(
       canPop: false,
       body: Center(


### PR DESCRIPTION
## 📝작업 내용
`image-to-food/analyze` API 연결했습니다.
- `CameraLoadingView`에 들어가면 이미지 분석 요청 보낸 후 `CameraAddView`로 이동합니다.

`CameraAddView`에서 분석된 식재료들을 표시하도록 수정했습니다.
- `FoodAddContainer`를 재활용해서 냉장, 냉동, 실온 보관에 사용할 수 있도록 수정했습니다.
- 식재료 선택 버튼을 추가했습니다. 화면은 선택 화면으로 변하지만 아직 선택 기능은 구현하지 않았습니다.

`IconSelection` 컴포넌트를 만들었습니다.
- 기존 `FoodSelect`, `ImageConfirmSelect`에 있던 선택 아이콘을 피그마에 맞춰서 분리했습니다.
- `IconSelectionType`을 통해서 색과 크기 등을 지정합니다. 디폴트는 `small` 입니다.

`Food` 오브젝트에서 `icon`과 `id` 디폴트 값을 추가했습니다.
- 임시로 당근 아이콘으로 해두긴 했는데, 나중에 제대로 된 아이콘 나오면 수정할 예정입니다.

## 스크린샷
<img src="https://github.com/user-attachments/assets/eb5da432-b427-49e5-83b0-e5ecec2013d5" width="200" />
<img src="https://github.com/user-attachments/assets/b09eec6d-7f92-4b09-8484-d2daabdea1f7" width="200" />

