### PR TITLE
feat: 분석한 식재료 선택 및 삭제 로직 추가

### DIFF
--- a/lib/components/camera/food_add_container.dart
+++ b/lib/components/camera/food_add_container.dart
@@ -4,14 +4,28 @@ import 'package:nutripic/objects/food.dart';
 import 'package:nutripic/utils/palette.dart';
 
 class FoodAddContainer extends StatelessWidget {
+  /// 컨테이너 제목
   final String title;
+
+  /// 인식된 식재료 리스트
   final List<Food> recognizedFoods;
+
+  /// 선택된 식재료
+  final Set<Food> selectedFoods;
+
+  /// 선택 모드 여부
   final bool isSelectState;
+
+  /// 식재료 선택시 콜백 함수
+  final Function(Food) select;
+
   const FoodAddContainer({
     super.key,
     required this.title,
     required this.recognizedFoods,
+    required this.selectedFoods,
     required this.isSelectState,
+    required this.select,
   });
 
   @override
@@ -47,7 +61,9 @@ class FoodAddContainer extends StatelessWidget {
                       RecognizedFoodTile(
                     food: recognizedFoods.elementAt(index),
                     isSelectState: isSelectState,
+                    isSelected: selectedFoods.contains(recognizedFoods[index]),
                     onTapEdit: () {},
+                    select: select,
                   ),
                 ),
               ),

--- a/lib/components/camera/recognized_food_tile.dart
+++ b/lib/components/camera/recognized_food_tile.dart
@@ -12,78 +12,91 @@ class RecognizedFoodTile extends StatelessWidget {
   /// 선택 모드
   final bool isSelectState;
 
+  /// 선택 됨 여부
+  final bool isSelected;
+
   /// 수정 버튼 클릭시 호출할 함수
   final Function()? onTapEdit;
+
+  /// 식재료 선택시 콜백 함수
+  final Function(Food) select;
 
   /// `name = filename.svg`
   const RecognizedFoodTile({
     super.key,
     required this.food,
     required this.isSelectState,
+    required this.isSelected,
     required this.onTapEdit,
+    required this.select,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        // 선택 버튼
-        if (isSelectState) const IconSelection(isSelected: false),
-        if (isSelectState) const SizedBox(width: 8),
+    return GestureDetector(
+      onTap: () => select(food),
+      behavior: HitTestBehavior.opaque,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // 선택 버튼
+          if (isSelectState) IconSelection(isSelected: isSelected),
+          if (isSelectState) const SizedBox(width: 8),
 
-        // 식재료 이미지
-        Container(
-          width: 56,
-          height: 56,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: Palette.gray200,
-              width: 1,
+          // 식재료 이미지
+          Container(
+            width: 56,
+            height: 56,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: Palette.gray200,
+                width: 1,
+              ),
             ),
+            child: SvgPicture.asset('assets/foods/${food.icon}.svg'),
           ),
-          child: SvgPicture.asset('assets/foods/${food.icon}.svg'),
-        ),
-        const SizedBox(width: 16),
+          const SizedBox(width: 16),
 
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // 유통기한
-            Container(
-              width: 45,
-              height: 22,
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                color: Palette.delete,
-                borderRadius: BorderRadius.circular(12),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // 유통기한
+              Container(
+                width: 45,
+                height: 22,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: Palette.delete,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  'D-5',
+                  style: Palette.caption1.copyWith(color: Palette.gray00),
+                ),
               ),
-              child: Text(
-                'D-5',
-                style: Palette.caption1.copyWith(color: Palette.gray00),
+              const SizedBox(height: 6),
+
+              // 식재료 이름
+              Text(
+                food.name,
+                style: Palette.body1.copyWith(color: Palette.gray900),
               ),
+            ],
+          ),
+
+          const Spacer(),
+
+          // 수정 버튼
+          if (!isSelectState)
+            ImageButton(
+              img: '/edit.svg',
+              width: 24,
+              height: 24,
+              onTap: onTapEdit,
             ),
-            const SizedBox(height: 6),
-
-            // 식재료 이름
-            Text(
-              food.name,
-              style: Palette.body1.copyWith(color: Palette.gray900),
-            ),
-          ],
-        ),
-
-        const Spacer(),
-
-        // 수정 버튼
-        ImageButton(
-          img: '/edit.svg',
-          width: 24,
-          height: 24,
-          onTap: onTapEdit,
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/lib/components/common/custom_app_bar.dart
+++ b/lib/components/common/custom_app_bar.dart
@@ -15,6 +15,12 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   /// 뒤로가기 버튼 표시 여부
   final bool backButton;
 
+  /// 닫기 버튼으로 표시 여부
+  final bool closeButton;
+
+  /// 뒤로가기 클릭시 호출 함수
+  final Function()? onPressedLeading;
+
   /// 하단 구분선 표시 여부
   final bool underLine;
 
@@ -30,8 +36,15 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
   /// `centerTitle` : 타이틀 중앙 정렬 여부
   /// - `false`인 경우 우측에 표시
   ///
-  /// `backBtn` : 뒤로가기 버튼 표시 여부
+  /// `backButton` : 뒤로가기 버튼 표시 여부
   /// - 뒤로가기 버튼이 표시되는 경우가 더 많아서 기본 값은 `true`로 설정
+  ///
+  /// `closeButton` : 닫기 버튼 표시 여부
+  /// - `backButton`이 활성화 상태일때만 사용 가능
+  /// - 기본 값은 `false`로 설정 (뒤로가기 버튼이 더 우선 순위)
+  ///
+  /// `onPressedLeading` : 뒤로가기 또는 닫기 버튼을 클릭했을 때 호출되는 함수
+  /// - `null`이면 `context.pop()`이 기본으로 실행 됨
   ///
   /// `underLine` : 하단 구분선 표시 여부
   /// - 기본 값은 `true`로 설정
@@ -43,6 +56,8 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.titleWidget,
     this.centerTitle = true,
     this.backButton = true,
+    this.onPressedLeading,
+    this.closeButton = false,
     this.underLine = true,
     this.actions,
   });
@@ -52,15 +67,16 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
     return AppBar(
       title: title != null ? Text(title!) : titleWidget,
       centerTitle: centerTitle,
-      leadingWidth: 32,
       leading: backButton
-          ? Padding(
-              padding: const EdgeInsets.only(left: 16),
-              child: IconButton(
-                onPressed: () => context.pop(),
-                icon: const Icon(Icons.arrow_back_ios, size: 24),
-              ),
-            )
+          ? closeButton
+              ? IconButton(
+                  onPressed: onPressedLeading ?? () => context.pop(),
+                  icon: const Icon(Icons.close_rounded, size: 24),
+                )
+              : IconButton(
+                  onPressed: onPressedLeading ?? () => context.pop(),
+                  icon: const Icon(Icons.arrow_back_ios_new_rounded, size: 24),
+                )
           : null,
       actions: [
         ...?actions,

--- a/lib/models/camera_model.dart
+++ b/lib/models/camera_model.dart
@@ -21,6 +21,15 @@ class CameraModel with ChangeNotifier {
   /// GPT 인식한 식재료
   List<List<Food>> analyzedFoods = [[], [], []];
 
+  /// 선택된 냉장고 식재료
+  Set<Food> selectedRefrigerator = {};
+
+  /// 선택된 냉동고 식재료
+  Set<Food> selectedFreezer = {};
+
+  /// 선택된 실온 식재료
+  Set<Food> selectedRoom = {};
+
   CameraModel({this.controller});
 
   /// 모델 초기화
@@ -44,6 +53,16 @@ class CameraModel with ChangeNotifier {
 
     // 인식한 식재료 초기화
     analyzedFoods = [[], [], []];
+
+    // 선택된 식재료 초기화
+    clearSelections();
+  }
+
+  /// 선택된 식재료 초기화
+  void clearSelections() {
+    selectedRefrigerator.clear();
+    selectedFreezer.clear();
+    selectedRoom.clear();
   }
 
   /// 카메라 로드
@@ -113,5 +132,28 @@ class CameraModel with ChangeNotifier {
   /// 사진 전송 후 GPT 인식한 식재료 가져오는 함수
   Future<void> getAnalyzedImages() async {
     analyzedFoods = await API.postImageToFood(images.first);
+  }
+
+  /// 선택된 식재료 삭제
+  void deleteFoods() {
+    try {
+      if (selectedRefrigerator.length == analyzedFoods[0].length &&
+          selectedFreezer.length == analyzedFoods[1].length &&
+          selectedRoom.length == analyzedFoods[2].length) {
+        // 최소 한개의 식재료는 남겨놔야 함
+        debugPrint('최소 한개의 식재료는 남아 있어야 합니다.');
+      } else {
+        // analyzedFoods에서 선택된 식재료를 리스트에서 삭제
+        analyzedFoods[0]
+            .removeWhere((food) => selectedRefrigerator.contains(food));
+        analyzedFoods[1].removeWhere((food) => selectedFreezer.contains(food));
+        analyzedFoods[2].removeWhere((food) => selectedRoom.contains(food));
+
+        // 삭제 후 선택된 식재료 초기화
+        clearSelections();
+      }
+    } catch (e) {
+      debugPrint('Error on deleteFoods');
+    }
   }
 }

--- a/lib/objects/food.dart
+++ b/lib/objects/food.dart
@@ -37,7 +37,7 @@ class Food {
   /// jsonData에서 받아온 데이터를 Food로 변환 저장하는 함수
   factory Food.fromJson(Map<String, dynamic> json) {
     return Food(
-      id: json['id'] ?? 0,
+      id: json['id'] ?? -1,
       name: json['name'],
       icon: json['icon'] ?? 'carrot',
       class1: json['class1'],
@@ -46,6 +46,19 @@ class Food {
       expireDate: DateTime.parse(json['expireDate']),
       expired: json['expired'],
     );
+  }
+
+  /// Food를 json으로 변환하는 함수
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'icon': icon,
+      'class1': class1,
+      'class2': class2,
+      'addedDate': addedDate.toIso8601String(),
+      'expireDate': expireDate.toIso8601String(),
+      'expired': expired,
+    };
   }
 
   @override

--- a/lib/utils/api.dart
+++ b/lib/utils/api.dart
@@ -142,10 +142,20 @@ class API {
   }
 
   /// 식재료를 DB에 등록하는 post 요청
-  static Future<void> postFoods(
-      List<Map<String, dynamic>> recognizedFoods) async {
+  static Future<void> postFoods(List<List<Food>> recognizedFoods) async {
     try {
-      await _postApi('/storage/add', jsonData: jsonEncode(recognizedFoods));
+      List<Map<String, dynamic>> data = [];
+      List<String> storageTypes = ['fridge', 'freezer', 'room'];
+
+      for (int i = 0; i < recognizedFoods.length; i++) {
+        for (Food food in recognizedFoods[i]) {
+          Map<String, dynamic> foodMap = food.toJson();
+          foodMap['storageType'] = storageTypes[i];
+          data.add(foodMap);
+        }
+      }
+
+      await _postApi('/storage/add', jsonData: jsonEncode(data));
     } catch (e) {
       debugPrint('Error in postFoods: $e');
       throw Error();

--- a/lib/view_models/camera/camera_add_view_model.dart
+++ b/lib/view_models/camera/camera_add_view_model.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nutripic/models/camera_model.dart';
 import 'package:nutripic/models/refrigerator_model.dart';
+import 'package:nutripic/objects/food.dart';
 import 'package:nutripic/utils/api.dart';
 
 class CameraAddViewModel with ChangeNotifier {
@@ -18,24 +19,91 @@ class CameraAddViewModel with ChangeNotifier {
 
   bool isSelectState = false;
 
+  void onPressClose() {
+    context.pop();
+    context.pop();
+  }
+
   void onPressSelect() {
     isSelectState = !isSelectState;
+    cameraModel.clearSelections();
     notifyListeners();
+  }
+
+  /// 냉장고 식재료 선택 함수
+  void selectRefrigeratorFood(Food food) {
+    if (isSelectState) {
+      if (!cameraModel.selectedRefrigerator.contains(food)) {
+        // selectedRefrigerator 없으면 새로 추가
+        cameraModel.selectedRefrigerator.add(food);
+      } else {
+        // selectedRefrigerator 이미 추가 돼있으면 제거
+        cameraModel.selectedRefrigerator.remove(food);
+      }
+
+      notifyListeners();
+    }
+  }
+
+  /// 냉동고 식재료 선택 함수
+  void selectFreezerFood(Food food) {
+    if (isSelectState) {
+      if (!cameraModel.selectedFreezer.contains(food)) {
+        // selectedFreezer 없으면 새로 추가
+        cameraModel.selectedFreezer.add(food);
+      } else {
+        // selectedFreezer 이미 추가 돼있으면 제거
+        cameraModel.selectedFreezer.remove(food);
+      }
+
+      notifyListeners();
+    }
+  }
+
+  /// 실온 식재료 선택 함수
+  void selectRoomFood(Food food) {
+    if (isSelectState) {
+      if (!cameraModel.selectedRoom.contains(food)) {
+        // selectedRoom 없으면 새로 추가
+        cameraModel.selectedRoom.add(food);
+      } else {
+        // selectedRoom 이미 추가 돼있으면 제거
+        cameraModel.selectedRoom.remove(food);
+      }
+
+      notifyListeners();
+    }
   }
 
   void onPressedSave() async {
     isLoading = true;
     notifyListeners();
 
-    // 식재료 등록
-    await API.postFoods([]);
-    // 식재료 리스트 다시 불러오기
-    // TODO: postFoods의 반환 값으로 로직 수정 필요
-    // await refrigeratorModel.getFoods();
+    if (isSelectState) {
+      // 선택된 식재료 리스트에서 삭제
+      cameraModel.deleteFoods();
+      isSelectState = false;
 
-    isLoading = false;
-    notifyListeners();
+      isLoading = false;
+      notifyListeners();
+    } else {
+      // 식재료 등록
+      await API.postFoods(cameraModel.analyzedFoods);
 
-    if (context.mounted) context.pop();
+      // 식재료 리스트 다시 불러오기
+      // id를 받아와야 하기 때문에 getFood를 실행해야 함
+      await refrigeratorModel.getFoods();
+
+      // 카메라 모델 초기화
+      cameraModel.reset();
+
+      isLoading = false;
+      notifyListeners();
+
+      // 냉장고 화면까지 pop 2번 해야됨
+      // refrigerator/camera/add
+      if (context.mounted) context.pop();
+      if (context.mounted) context.pop();
+    }
   }
 }

--- a/lib/view_models/camera/camera_confirm_view_model.dart
+++ b/lib/view_models/camera/camera_confirm_view_model.dart
@@ -69,7 +69,7 @@ class CameraConfirmViewModel with ChangeNotifier {
       // 카메라 컨트롤러 제거
       cameraModel.controller?.dispose();
 
-      context.go('/refrigerator/loading');
+      context.pushReplacement('/refrigerator/loading');
     }
   }
 }

--- a/lib/view_models/camera/camera_loading_view_model.dart
+++ b/lib/view_models/camera/camera_loading_view_model.dart
@@ -16,6 +16,6 @@ class CameraLoadingViewModel with ChangeNotifier {
     await cameraModel.getAnalyzedImages();
 
     // 이미지 저장 후 최종 확인 페이지로 이동
-    if (context.mounted) context.go('/refrigerator/add');
+    if (context.mounted) context.pushReplacement('/refrigerator/add');
   }
 }

--- a/lib/view_models/camera/camera_view_model.dart
+++ b/lib/view_models/camera/camera_view_model.dart
@@ -53,11 +53,10 @@ class CameraViewModel with ChangeNotifier {
   }
 
   /// 식재료 추가 확인 페이지로 이동
-  void onTapComplete() async {
+  void onTapComplete() {
     // 촬영한 사진이 있을 때만 이동
     if (cameraModel.images.isNotEmpty) {
-      await context.push('/refrigerator/camera/confirm');
-      notifyListeners();
+      context.push('/refrigerator/camera/confirm');
     }
   }
 

--- a/lib/view_models/refrigerator/refrigerator_view_model.dart
+++ b/lib/view_models/refrigerator/refrigerator_view_model.dart
@@ -98,10 +98,7 @@ class RefrigeratorViewModel with ChangeNotifier {
     cameraModel.reset();
 
     // 식재료 추가 후 냉장고 화면 업데이트를 위해서 비동기 처리
-    await GoRouter.of(context).push('/refrigerator/camera');
-
-    // 업데이트된 식재료 다시 서버에서 불러오기
-    await refrigeratorModel.getFoods();
+    await context.push('/refrigerator/camera');
     notifyListeners();
   }
 }

--- a/lib/views/camera/camera_add_view.dart
+++ b/lib/views/camera/camera_add_view.dart
@@ -20,12 +20,16 @@ class CameraAddView extends StatelessWidget {
     return CustomScaffold(
       appBar: CustomAppBar(
         title: '분석 결과',
+        closeButton: true,
+        onPressedLeading: cameraAddViewModel.onPressClose,
         actions: [
           BoxButton(
-              label: cameraAddViewModel.isSelectState ? '취소' : '선택',
-              onPressed: cameraAddViewModel.onPressSelect),
+            label: cameraAddViewModel.isSelectState ? '취소' : '선택',
+            onPressed: cameraAddViewModel.onPressSelect,
+          ),
         ],
       ),
+      canPop: false,
       isLoading: cameraAddViewModel.isLoading,
       body: CustomScrollView(
         shrinkWrap: true,
@@ -41,7 +45,10 @@ class CameraAddView extends StatelessWidget {
                   title: '냉장보관',
                   recognizedFoods:
                       cameraAddViewModel.cameraModel.analyzedFoods[0],
+                  selectedFoods:
+                      cameraAddViewModel.cameraModel.selectedRefrigerator,
                   isSelectState: cameraAddViewModel.isSelectState,
+                  select: cameraAddViewModel.selectRefrigeratorFood,
                 ),
 
                 // 인식된 식재료 리스트
@@ -49,7 +56,9 @@ class CameraAddView extends StatelessWidget {
                   title: '냉동보관',
                   recognizedFoods:
                       cameraAddViewModel.cameraModel.analyzedFoods[1],
+                  selectedFoods: cameraAddViewModel.cameraModel.selectedFreezer,
                   isSelectState: cameraAddViewModel.isSelectState,
+                  select: cameraAddViewModel.selectFreezerFood,
                 ),
 
                 // 인식된 식재료 리스트
@@ -57,7 +66,9 @@ class CameraAddView extends StatelessWidget {
                   title: '실온보관',
                   recognizedFoods:
                       cameraAddViewModel.cameraModel.analyzedFoods[2],
+                  selectedFoods: cameraAddViewModel.cameraModel.selectedRoom,
                   isSelectState: cameraAddViewModel.isSelectState,
+                  select: cameraAddViewModel.selectRoomFood,
                 ),
               ],
             ),
@@ -105,7 +116,6 @@ class CameraAddView extends StatelessWidget {
           ),
         ],
       ),
-      // ),
     );
   }
 }


### PR DESCRIPTION
## 📝작업 내용
GPT 분석한 식재료 선택 및 삭제 로직 추가했습니다.
- `FoodAddContainer`와 `RecognizedFoodTile`에 선택 로직을 추가했습니다. 
- `CameraModel`에 식재료 선택 및 삭제 로직을 추가했습니다.
- `postFoods` API에 `analyzedFoods` 리스트를 요청 dto에 맞춰 리스트 전환 후 전송하도록 로직을 수정했습니다.

`CustomAppBar`에 닫기 버튼을 추가했습니다.
- `closeButton`을 통해서 뒤로가기 또는 닫기 중에서 선택할 수 있습니다.
- 뒤로가기 버튼이 더 높은 우선 순위를 가집니다. `backButton`이 활성화되지 않은면 뒤로가기 버튼도 활성화되지 않습니다.
- enum을 활용하면 더 직관적으로 구현이 가능할 것 같은데 그러면 좀 갈아엎을 부분들이 있어 보여서 기존 코드를 최대한 바꾸지 않는 방향으로 작업했습니다. 추후에 다시 고민해보겠습니다.

식재료 추가 후 냉장고에 반영이 되도록 라우팅 로직을 일부 수정했습니다.
