### PR TITLE
feat: 식재료 수동 입력 페이지 구현

### DIFF
--- a/lib/components/camera/food_add_container.dart
+++ b/lib/components/camera/food_add_container.dart
@@ -19,6 +19,9 @@ class FoodAddContainer extends StatelessWidget {
   /// 식재료 선택시 콜백 함수
   final Function(Food) select;
 
+  /// 식재료 수정 함수
+  final Function(Food) onTapEdit;
+
   const FoodAddContainer({
     super.key,
     required this.title,
@@ -26,6 +29,7 @@ class FoodAddContainer extends StatelessWidget {
     required this.selectedFoods,
     required this.isSelectState,
     required this.select,
+    required this.onTapEdit,
   });
 
   @override
@@ -62,7 +66,7 @@ class FoodAddContainer extends StatelessWidget {
                     food: recognizedFoods.elementAt(index),
                     isSelectState: isSelectState,
                     isSelected: selectedFoods.contains(recognizedFoods[index]),
-                    onTapEdit: () {},
+                    onTapEdit: onTapEdit,
                     select: select,
                   ),
                 ),

--- a/lib/components/camera/recognized_food_tile.dart
+++ b/lib/components/camera/recognized_food_tile.dart
@@ -16,7 +16,7 @@ class RecognizedFoodTile extends StatelessWidget {
   final bool isSelected;
 
   /// 수정 버튼 클릭시 호출할 함수
-  final Function()? onTapEdit;
+  final Function(Food) onTapEdit;
 
   /// 식재료 선택시 콜백 함수
   final Function(Food) select;
@@ -93,7 +93,7 @@ class RecognizedFoodTile extends StatelessWidget {
               img: '/edit.svg',
               width: 24,
               height: 24,
-              onTap: onTapEdit,
+              onTap: () => onTapEdit(food),
             ),
         ],
       ),

--- a/lib/components/custom_drop_down.dart
+++ b/lib/components/custom_drop_down.dart
@@ -1,0 +1,98 @@
+import 'package:dropdown_button2/dropdown_button2.dart';
+import 'package:flutter/material.dart';
+import 'package:nutripic/utils/palette.dart';
+
+class CustomDropDown extends StatefulWidget {
+  final String? label;
+  final String? hintText;
+  final String? defaultValue;
+  final List<String> items;
+  final ValueChanged<String?> onChanged;
+  const CustomDropDown({
+    super.key,
+    this.label,
+    this.hintText,
+    this.defaultValue,
+    required this.items,
+    required this.onChanged,
+  });
+
+  @override
+  State<CustomDropDown> createState() => _CustomDropDownState();
+}
+
+class _CustomDropDownState extends State<CustomDropDown> {
+  String? selectedValue;
+
+  @override
+  void initState() {
+    super.initState();
+    selectedValue = widget.defaultValue;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // 레이블
+        if (widget.label != null)
+          Text(
+            widget.label!,
+            style: Palette.body2.copyWith(color: Palette.gray400),
+          ),
+
+        if (widget.label != null) const SizedBox(height: 6),
+
+        DropdownButton2(
+          hint: Text(
+            widget.hintText ?? '선택하세요',
+            style: Palette.body1.copyWith(color: Palette.gray400),
+          ),
+          underline: const SizedBox(), // underline 제거
+          buttonStyleData: ButtonStyleData(
+            width: double.infinity,
+            height: 48,
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            decoration: BoxDecoration(
+              color: Palette.gray50,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: Palette.gray100),
+            ),
+          ),
+          dropdownStyleData: DropdownStyleData(
+            decoration: BoxDecoration(
+              color: Palette.gray50,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: Palette.gray100),
+            ),
+            elevation: 0,
+          ),
+          isExpanded: true,
+          value: selectedValue,
+          items: widget.items
+              .map(
+                (String item) => DropdownMenuItem<String>(
+                  value: item,
+                  child: Text(
+                    item,
+                    style: Palette.body1.copyWith(color: Palette.gray900),
+                  ),
+                ),
+              )
+              .toList(),
+          onChanged: (value) {
+            // 선택된 항목 업데이트
+            setState(() {
+              selectedValue = value;
+            });
+
+            // 선택된 항목 반환
+            widget.onChanged(value);
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/objects/food.dart
+++ b/lib/objects/food.dart
@@ -3,25 +3,25 @@ class Food {
   final int id;
 
   /// 식재료 이름
-  final String name;
+  String name;
 
   /// 아이콘 이름
-  final String icon;
+  String icon;
 
   /// 대분류
-  final String class1;
+  String class1;
 
   /// 소분류
-  final String class2;
+  String class2;
 
   /// 식재료가 추가된 날짜
   final DateTime addedDate;
 
   /// 유통기한
-  final DateTime expireDate;
+  DateTime expireDate;
 
   /// 유통기한 지났는지 여부
-  final bool expired;
+  bool expired;
 
   Food({
     required this.id,
@@ -55,15 +55,36 @@ class Food {
       'icon': icon,
       'class1': class1,
       'class2': class2,
-      'addedDate': addedDate.toIso8601String(),
-      'expireDate': expireDate.toIso8601String(),
+      'addedDate': addedDate.toUtc().toIso8601String(),
+      'expireDate': expireDate.toUtc().toIso8601String(),
       'expired': expired,
     };
   }
 
+  /// 식재료 값 수정하는 함수
+  /// <br /> `id`, `addedDate`는 수정 불가
+  void update({
+    String? name,
+    String? icon,
+    String? class1,
+    String? class2,
+    DateTime? expireDate,
+    bool? expired,
+  }) {
+    this.name = name ?? this.name;
+    this.icon = icon ?? this.icon;
+    this.class1 = class1 ?? this.class1;
+    this.class2 = class2 ?? this.class2;
+    this.expireDate = expireDate ?? this.expireDate;
+    this.expired = expired ?? this.expired;
+  }
+
   @override
   String toString() {
-    return 'name: $name, '
+    return 'id: $id, '
+        'name: $name, '
+        'class1: $class1, '
+        'class2: $class2, '
         'expireDate: $expireDate';
   }
 }

--- a/lib/utils/app_router.dart
+++ b/lib/utils/app_router.dart
@@ -10,6 +10,7 @@ import 'package:nutripic/view_models/camera/camera_add_view_model.dart';
 import 'package:nutripic/view_models/camera/camera_confirm_view_model.dart';
 import 'package:nutripic/view_models/camera/camera_loading_view_model.dart';
 import 'package:nutripic/view_models/camera/camera_view_model.dart';
+import 'package:nutripic/view_models/camera/food_edit_view_model.dart';
 import 'package:nutripic/view_models/diary/diary_post_view_model.dart';
 import 'package:nutripic/view_models/diary/diary_record_view_model.dart';
 import 'package:nutripic/view_models/diary/diary_view_model.dart';
@@ -26,6 +27,7 @@ import 'package:nutripic/view_models/user_info/user_info_view_model.dart';
 import 'package:nutripic/views/camera/camera_add_view.dart';
 import 'package:nutripic/views/camera/camera_confirm_view.dart';
 import 'package:nutripic/views/camera/camera_loading_view.dart';
+import 'package:nutripic/views/camera/food_edit_view.dart';
 import 'package:nutripic/views/diary/diary_record_view.dart';
 import 'package:nutripic/views/diary/diary_view.dart';
 import 'package:nutripic/views/login/email_view.dart';
@@ -193,6 +195,23 @@ class AppRouter {
                         ),
                         child: const CameraAddView(),
                       ),
+                      routes: [
+                        GoRoute(
+                          path: 'edit',
+                          parentNavigatorKey: _rootNavigatorKey,
+                          builder: (context, state) => ChangeNotifierProvider(
+                            create: (context) => FoodEditViewModel(
+                              cameraModel: cameraModel,
+                              food:
+                                  (state.extra as Map<String, dynamic>)['food'],
+                              storage: (state.extra
+                                  as Map<String, dynamic>)['storage'],
+                              context: context,
+                            ),
+                            child: const FoodEditView(),
+                          ),
+                        ),
+                      ],
                     ),
                   ],
                 )

--- a/lib/utils/enums/storage_type.dart
+++ b/lib/utils/enums/storage_type.dart
@@ -7,4 +7,8 @@ enum StorageType {
   final int rawValue;
   final String name;
   const StorageType(this.rawValue, this.name);
+
+  factory StorageType.fromString(String name) {
+    return StorageType.values.firstWhere((value) => value.name == name);
+  }
 }

--- a/lib/view_models/camera/camera_add_view_model.dart
+++ b/lib/view_models/camera/camera_add_view_model.dart
@@ -4,6 +4,7 @@ import 'package:nutripic/models/camera_model.dart';
 import 'package:nutripic/models/refrigerator_model.dart';
 import 'package:nutripic/objects/food.dart';
 import 'package:nutripic/utils/api.dart';
+import 'package:nutripic/utils/enums/storage_type.dart';
 
 class CameraAddViewModel with ChangeNotifier {
   RefrigeratorModel refrigeratorModel;
@@ -75,6 +76,19 @@ class CameraAddViewModel with ChangeNotifier {
     }
   }
 
+  /// 등록하기, 편집 버튼 클릭
+  void onPressedEdit({Food? food, StorageType? storage}) async {
+    if (context.mounted) {
+      await context.push(
+        '/refrigerator/add/edit',
+        extra: {'food': food, 'storage': storage},
+      );
+    }
+
+    notifyListeners();
+  }
+
+  /// 보관/삭제하기 버튼 클릭
   void onPressedSave() async {
     isLoading = true;
     notifyListeners();

--- a/lib/view_models/camera/food_edit_view_model.dart
+++ b/lib/view_models/camera/food_edit_view_model.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nutripic/models/camera_model.dart';
+import 'package:nutripic/objects/food.dart';
+import 'package:nutripic/utils/enums/storage_type.dart';
+
+class FoodEditViewModel with ChangeNotifier {
+  CameraModel cameraModel;
+  Food? food;
+  StorageType? storage;
+  BuildContext context;
+
+  FoodEditViewModel({
+    required this.cameraModel,
+    this.food,
+    this.storage,
+    required this.context,
+  }) {
+    if (food != null && storage != null) {
+      name.text = food!.name;
+      selectedClass1 = food!.class1;
+      selectedClass2 = food!.class2;
+      selectedStorage = storage!;
+    }
+  }
+
+  /// 식재료명 TextEditingController
+  final TextEditingController name = TextEditingController();
+
+  final List<String> class1 = ['채소'];
+  final List<String> class2 = ['당근', '토마토', '감자'];
+  final List<String> storages = [
+    StorageType.fridge.name,
+    StorageType.freezer.name,
+    StorageType.room.name,
+  ];
+
+  String? selectedClass1;
+  String? selectedClass2;
+  StorageType? selectedStorage;
+
+  /// Appbar 제목
+  String appbarTitle() => food == null ? '식재료 등록하기' : '식재료 수정하기';
+
+  /// 등록 버튼 레이블
+  String editButtonLabel() => food == null ? '등록하기' : '수정하기';
+
+  /// 대분류 드롭다운 선택
+  void selectClass1(String? value) {
+    if (value != null) {
+      selectedClass1 = value;
+    }
+  }
+
+  /// 소분류 드롭다운 선택
+  void selectClass2(String? value) {
+    if (value != null) {
+      selectedClass2 = value;
+    }
+  }
+
+  /// 저장소 드롭다운 선택
+  void selectStorage(String? value) {
+    if (value != null) {
+      selectedStorage = StorageType.fromString(value);
+    }
+  }
+
+  /// 등록하기 버튼 클릭
+  void onPressedSave() {
+    if (selectedClass1 != null &&
+        selectedClass2 != null &&
+        selectedStorage != null) {
+      // 수정
+      if (food != null && storage != null) {
+        final index = cameraModel.analyzedFoods[storage!.rawValue]
+            .indexWhere((food) => food == this.food);
+
+        if (selectedStorage == storage) {
+          // 저장 위치를 변경하지 않았다면 그대로 업데이트
+          cameraModel.analyzedFoods[storage!.rawValue][index].update(
+            name: name.text.trim(),
+            class1: selectedClass1!,
+            class2: selectedClass2!,
+          );
+
+          context.pop();
+          return;
+        } else {
+          // 저장 위치를 변경했다면 기존 저장소에서 제거
+          cameraModel.analyzedFoods[storage!.rawValue].removeAt(index);
+        }
+      }
+
+      // 새 식재료 등록
+      final newFood = Food(
+        id: -1,
+        name: name.text.trim(),
+        icon: food?.icon ?? 'carrot',
+        class1: selectedClass1!,
+        class2: selectedClass2!,
+        addedDate: food?.addedDate ?? DateTime.now(),
+        expireDate: food?.expireDate ?? DateTime.now(),
+        expired: food?.expired ?? false,
+      );
+      cameraModel.analyzedFoods[selectedStorage!.rawValue].add(newFood);
+
+      context.pop();
+    }
+  }
+}

--- a/lib/views/camera/camera_add_view.dart
+++ b/lib/views/camera/camera_add_view.dart
@@ -6,6 +6,7 @@ import 'package:nutripic/components/common/custom_scaffold.dart';
 import 'package:nutripic/components/main_button.dart';
 import 'package:nutripic/utils/enums/box_button_type.dart';
 import 'package:nutripic/utils/enums/main_button_type.dart';
+import 'package:nutripic/utils/enums/storage_type.dart';
 import 'package:nutripic/utils/palette.dart';
 import 'package:nutripic/view_models/camera/camera_add_view_model.dart';
 import 'package:provider/provider.dart';
@@ -49,6 +50,10 @@ class CameraAddView extends StatelessWidget {
                       cameraAddViewModel.cameraModel.selectedRefrigerator,
                   isSelectState: cameraAddViewModel.isSelectState,
                   select: cameraAddViewModel.selectRefrigeratorFood,
+                  onTapEdit: (food) => cameraAddViewModel.onPressedEdit(
+                    food: food,
+                    storage: StorageType.fridge,
+                  ),
                 ),
 
                 // 인식된 식재료 리스트
@@ -59,6 +64,10 @@ class CameraAddView extends StatelessWidget {
                   selectedFoods: cameraAddViewModel.cameraModel.selectedFreezer,
                   isSelectState: cameraAddViewModel.isSelectState,
                   select: cameraAddViewModel.selectFreezerFood,
+                  onTapEdit: (food) => cameraAddViewModel.onPressedEdit(
+                    food: food,
+                    storage: StorageType.freezer,
+                  ),
                 ),
 
                 // 인식된 식재료 리스트
@@ -69,6 +78,10 @@ class CameraAddView extends StatelessWidget {
                   selectedFoods: cameraAddViewModel.cameraModel.selectedRoom,
                   isSelectState: cameraAddViewModel.isSelectState,
                   select: cameraAddViewModel.selectRoomFood,
+                  onTapEdit: (food) => cameraAddViewModel.onPressedEdit(
+                    food: food,
+                    storage: StorageType.room,
+                  ),
                 ),
               ],
             ),
@@ -98,7 +111,7 @@ class CameraAddView extends StatelessWidget {
                     label: '등록하기',
                     type: BoxButtonType.primary,
                     s: false,
-                    onPressed: () {},
+                    onPressed: cameraAddViewModel.onPressedEdit,
                   ),
                 if (!cameraAddViewModel.isSelectState)
                   const SizedBox(height: 40),

--- a/lib/views/camera/food_edit_view.dart
+++ b/lib/views/camera/food_edit_view.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:nutripic/components/common/custom_app_bar.dart';
+import 'package:nutripic/components/common/custom_scaffold.dart';
+import 'package:nutripic/components/custom_drop_down.dart';
+import 'package:nutripic/components/custom_text_field.dart';
+import 'package:nutripic/components/main_button.dart';
+import 'package:nutripic/view_models/camera/food_edit_view_model.dart';
+import 'package:provider/provider.dart';
+
+class FoodEditView extends StatelessWidget {
+  const FoodEditView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    FoodEditViewModel foodEditViewModel = context.watch<FoodEditViewModel>();
+
+    return CustomScaffold(
+      appBar: CustomAppBar(title: foodEditViewModel.appbarTitle()),
+      resizeToAvoidBottomInset: false,
+      body: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const SizedBox(height: 32),
+
+          CustomTextField(
+            label: '식재료명',
+            hintText: '식재료 이름을 입력하세요.',
+            controller: foodEditViewModel.name,
+          ),
+          const SizedBox(height: 16),
+
+          CustomDropDown(
+            label: '대분류',
+            hintText: '대분류를 선택하세요.',
+            items: foodEditViewModel.class1,
+            defaultValue: foodEditViewModel.selectedClass1,
+            onChanged: (value) => foodEditViewModel.selectClass1(value),
+          ),
+
+          const SizedBox(height: 16),
+
+          CustomDropDown(
+            label: '소분류',
+            hintText: '소분류를 선택하세요.',
+            items: foodEditViewModel.class2,
+            defaultValue: foodEditViewModel.selectedClass2,
+            onChanged: (value) => foodEditViewModel.selectClass2(value),
+          ),
+          const SizedBox(height: 16),
+
+          CustomDropDown(
+            label: '보관 장소',
+            hintText: '보관 장소를 선택하세요.',
+            items: foodEditViewModel.storages,
+            defaultValue: foodEditViewModel.selectedStorage?.name,
+            onChanged: (value) => foodEditViewModel.selectStorage(value),
+          ),
+          const Spacer(),
+
+          // 등록 버튼
+          MainButton(
+            label: foodEditViewModel.editButtonLabel(),
+            onPressed: foodEditViewModel.onPressedSave,
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   camera: ^0.11.0+2
   camera_android_camerax: 0.6.10+1
   dio: ^5.7.0
+  dropdown_button2: ^2.3.9
   firebase_auth: ^5.3.0
   firebase_core: ^3.5.0
   flutter:


### PR DESCRIPTION
## 📝작업 내용
식재료 수동 입력 페이지 만들었습니다.
- `Food`, `Storage` 유무에 따라서 동일한 페이지에서 등록과 수정 모두 가능합니다. (`FoodEditViewModel` 참조)
  - `food`와 `storage`가 존재하고, 저장소가 바뀌지 않았다면 수정만 진행합니다. 
  - 저장소가 변경되었거나 `food`, `storage`가 존재하지 않는다면 새로운 식재료를 등록합니다. (변경시에는 기존 저장소에서 제거합니다.

`CustomDropDown` 컴포넌트 만들었습니다.
- 기본 드롭다운은 커스텀이 불가능해 `dropdown button 2` 패키지를 추가했습니다.
-  아직 피그마 작업이 안돼서 `CustomTextField` 참고해서 동일한 모양으로 만들었습니다. 디자인 나오면 다시 수정하겠습니다.

`Food` 오브젝트에 데이터 업데이트하는 함수 구현했습니다. 
- `id`와 `addedDate`는 업데이트가 불가능하도록 했습니다.

`String` 값을 입력해서 `StorageType`을 반환하는 함수 만들었습니다.

## 스크린샷
<img src="https://github.com/user-attachments/assets/3239c330-0e30-4aa3-a200-b03e25b38efc" width="200" />
<img src="https://github.com/user-attachments/assets/f5e741cf-9a97-4b83-ba26-8479bfb01718" width="200" />

## 리뷰 요구사항
대분류, 소분류 리스트를 받아오는 기능이 없어서 하드코딩으로 입력해둔 대분류(채소), 소분류(당근, 토마토, 감자) 리스트에 존재하지 않는 분류가 나오면 오류가 납니다. 참고해주세요. 

유통기한 달력 추가해야하네요.. 