### PR TITLE
feat: 분석 실패 페이지 구현

### DIFF
--- a/lib/components/box_button.dart
+++ b/lib/components/box_button.dart
@@ -13,6 +13,9 @@ class BoxButton extends StatelessWidget {
   /// <br /> `true` = small
   final bool s;
 
+  /// 넓이
+  final double? width;
+
   /// 버튼 클릭
   final Function()? onPressed;
 
@@ -21,13 +24,14 @@ class BoxButton extends StatelessWidget {
     required this.label,
     this.type = BoxButtonType.normal,
     this.s = true,
+    this.width,
     required this.onPressed,
   });
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: s ? 56 : 80,
+      width: width ?? (s ? 56 : 80),
       height: s ? 32 : 36,
       child: FilledButton(
         onPressed: onPressed,

--- a/lib/models/camera_model.dart
+++ b/lib/models/camera_model.dart
@@ -130,8 +130,13 @@ class CameraModel with ChangeNotifier {
   }
 
   /// 사진 전송 후 GPT 인식한 식재료 가져오는 함수
-  Future<void> getAnalyzedImages() async {
-    analyzedFoods = await API.postImageToFood(images.first);
+  Future<bool> getAnalyzedImages() async {
+    try {
+      analyzedFoods = await API.postImageToFood(images.first);
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
 
   /// 선택된 식재료 삭제

--- a/lib/utils/app_router.dart
+++ b/lib/utils/app_router.dart
@@ -8,6 +8,7 @@ import 'package:nutripic/models/refrigerator_model.dart';
 import 'package:nutripic/models/user_model.dart';
 import 'package:nutripic/view_models/camera/camera_add_view_model.dart';
 import 'package:nutripic/view_models/camera/camera_confirm_view_model.dart';
+import 'package:nutripic/view_models/camera/camera_loading_fail_view_model.dart';
 import 'package:nutripic/view_models/camera/camera_loading_view_model.dart';
 import 'package:nutripic/view_models/camera/camera_view_model.dart';
 import 'package:nutripic/view_models/diary/diary_post_view_model.dart';
@@ -25,6 +26,7 @@ import 'package:nutripic/view_models/user_info/user_edit_view_model.dart';
 import 'package:nutripic/view_models/user_info/user_info_view_model.dart';
 import 'package:nutripic/views/camera/camera_add_view.dart';
 import 'package:nutripic/views/camera/camera_confirm_view.dart';
+import 'package:nutripic/views/camera/camera_loading_fail_view.dart';
 import 'package:nutripic/views/camera/camera_loading_view.dart';
 import 'package:nutripic/views/diary/diary_record_view.dart';
 import 'package:nutripic/views/diary/diary_view.dart';
@@ -179,6 +181,17 @@ class AppRouter {
                           context: context,
                         ),
                         child: const CameraLoadingView(),
+                      ),
+                    ),
+                    // 분석 실패 화면
+                    GoRoute(
+                      path: 'fail',
+                      parentNavigatorKey: _rootNavigatorKey,
+                      builder: (context, state) => ChangeNotifierProvider(
+                        create: (context) => CameraLoadingFailViewModel(
+                          context: context,
+                        ),
+                        child: const CameraLoadingFailView(),
                       ),
                     ),
                     // 식재료 추가

--- a/lib/view_models/camera/camera_add_view_model.dart
+++ b/lib/view_models/camera/camera_add_view_model.dart
@@ -20,6 +20,9 @@ class CameraAddViewModel with ChangeNotifier {
   bool isSelectState = false;
 
   void onPressClose() {
+    cameraModel.reset();
+
+    context.pop();
     context.pop();
     context.pop();
   }
@@ -102,6 +105,7 @@ class CameraAddViewModel with ChangeNotifier {
 
       // 냉장고 화면까지 pop 2번 해야됨
       // refrigerator/camera/add
+      if (context.mounted) context.pop();
       if (context.mounted) context.pop();
       if (context.mounted) context.pop();
     }

--- a/lib/view_models/camera/camera_confirm_view_model.dart
+++ b/lib/view_models/camera/camera_confirm_view_model.dart
@@ -66,10 +66,7 @@ class CameraConfirmViewModel with ChangeNotifier {
   void onTapSend() {
     // 분석할 이미지가 있을 때만 작동
     if (cameraModel.images.isNotEmpty) {
-      // 카메라 컨트롤러 제거
-      cameraModel.controller?.dispose();
-
-      context.pushReplacement('/refrigerator/loading');
+      context.push('/refrigerator/loading');
     }
   }
 }

--- a/lib/view_models/camera/camera_loading_fail_view_model.dart
+++ b/lib/view_models/camera/camera_loading_fail_view_model.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class CameraLoadingFailViewModel with ChangeNotifier {
+  BuildContext context;
+  CameraLoadingFailViewModel({required this.context});
+
+  /// 다시 분석하기 버튼 클릭
+  void onPressedRedo() {
+    context.pop();
+  }
+}

--- a/lib/view_models/camera/camera_loading_view_model.dart
+++ b/lib/view_models/camera/camera_loading_view_model.dart
@@ -13,9 +13,14 @@ class CameraLoadingViewModel with ChangeNotifier {
   /// 이미지 전송 후 GPT 인식한 식재료를 모델에 저장하는 함수
   void analyzeImage() async {
     // 이미지 분석
-    await cameraModel.getAnalyzedImages();
+    final analyzed = await cameraModel.getAnalyzedImages();
 
-    // 이미지 저장 후 최종 확인 페이지로 이동
-    if (context.mounted) context.pushReplacement('/refrigerator/add');
+    if (analyzed) {
+      // 이미지 저장 후 최종 확인 페이지로 이동
+      if (context.mounted) context.pushReplacement('/refrigerator/add');
+    } else {
+      // 분석 실패 페이지 이동
+      if (context.mounted) context.pushReplacement('/refrigerator/fail');
+    }
   }
 }

--- a/lib/view_models/camera/camera_view_model.dart
+++ b/lib/view_models/camera/camera_view_model.dart
@@ -53,10 +53,12 @@ class CameraViewModel with ChangeNotifier {
   }
 
   /// 식재료 추가 확인 페이지로 이동
-  void onTapComplete() {
+  void onTapComplete() async {
     // 촬영한 사진이 있을 때만 이동
     if (cameraModel.images.isNotEmpty) {
-      context.push('/refrigerator/camera/confirm');
+      // 사진 삭제 후 되돌아오는 경우를 대비해 async await 처리
+      await context.push('/refrigerator/camera/confirm');
+      notifyListeners();
     }
   }
 

--- a/lib/views/camera/camera_loading_fail_view.dart
+++ b/lib/views/camera/camera_loading_fail_view.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:nutripic/components/box_button.dart';
+import 'package:nutripic/components/common/custom_scaffold.dart';
+import 'package:nutripic/utils/enums/box_button_type.dart';
+import 'package:nutripic/utils/palette.dart';
+import 'package:nutripic/view_models/camera/camera_loading_fail_view_model.dart';
+import 'package:provider/provider.dart';
+
+class CameraLoadingFailView extends StatelessWidget {
+  const CameraLoadingFailView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    CameraLoadingFailViewModel cameraLoadingFailViewModel =
+        context.watch<CameraLoadingFailViewModel>();
+
+    return CustomScaffold(
+      canPop: false,
+      body: Center(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              '분석에 실패했어요',
+              style: Palette.title1Medium.copyWith(color: Palette.green600),
+            ),
+            const SizedBox(height: 24),
+            BoxButton(
+              label: '다시 분석하기',
+              type: BoxButtonType.primary,
+              s: false,
+              width: 100,
+              onPressed: cameraLoadingFailViewModel.onPressedRedo,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 📝작업 내용
GPT에서 이미지 분석 실패시 이동하는 분석 실패 페이지 구현했습니다.
- `/storage/add` api 작업 후 분성 성공 여부를 `bool` 형식으로 반환하도록 했습니다.
- 카메라 페이지로 되돌아갈 수 있도록 라우팅 과정을 조금 수정했습니다.

`BoxButton` 컴포넌트 넓이를 수동으로 입력할 수 있도록 했습니다.
- `width`가 가장 큰 우선 순위를 갖습니다. 
- `width`가 없는 경우 `s`에 따라 넓이가 56 또는 80으로 지정됩니다.

촬영한 사진 삭제 후 카메라로 돌아오면 제대로 반영되지 않는 문제를 해결했습니다. 

## 스크린샷
<img src="https://github.com/user-attachments/assets/122e01b7-bbc3-415f-aa62-e735fbcc49ac" width="200" />
